### PR TITLE
Open EMME GUI after creating EMME project

### DIFF
--- a/Scripts/assignment/emme_bindings/emme_project.py
+++ b/Scripts/assignment/emme_bindings/emme_project.py
@@ -24,15 +24,22 @@ class EmmeProject:
         Path to emmebank file (if EMME project is not initialized)
     project_name : str (optional)
         For naming project
+    visible : bool (optional)
+        Whether an EMME GUI window should be opened
     """
     def __init__(self,
                  project_path: str,
                  emmebank_path: Optional[str] = None,
-                 project_name: Optional[str] = None):
+                 project_name: Optional[str] = None,
+                 visible: Optional[bool] = False):
         log.info("Starting Emme...")
         if TYPE_CHECKING: self.cm: Optional[ContentManager] = None #type checker hint
-        emme_desktop = _app.start_dedicated(
-            project=project_path, visible=False, user_initials="HSL")
+        kwargs = {
+            "project": project_path,
+            "visible": visible,
+            "user_initials": "TC"}
+        emme_desktop = (_app.start(**kwargs) if visible
+            else _app.start_dedicated(**kwargs))
         if emmebank_path is not None:
             db = emme_desktop.data_explorer().add_database(emmebank_path)
             db.open()

--- a/Scripts/create_emme_project.py
+++ b/Scripts/create_emme_project.py
@@ -109,7 +109,7 @@ def create_emme_project(args):
     eb.create_scenario(scenario_num)
     emmebank_path = eb.path
     eb.dispose()
-    EmmeProject(project_path, emmebank_path, project_name)
+    EmmeProject(project_path, emmebank_path, project_name, visible=True)
 
 if __name__ == "__main__":
     # Initially read defaults from config file ("dev-config.json")


### PR DESCRIPTION
If enabling `visible`, `_app.start()` will be used instead of `_app_start_dedicated()`, so that it will stay active after python script ends.