### PR TITLE
Add runtime params --long-dist-demand-forecast and --freight-matrix-path

### DIFF
--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -72,11 +72,14 @@ If you are trying another model, fill in whatever the path is.
 
 There should be two directiories under the path: `2018_zonedata` and `Matrices`.
 The names of these directories are hardcoded.
-There are 13 different input vector files in `2018_zonedata` from `.car` to `.wrk`.
-`Matrices` contains `.omx` files for demand, external traffic and freight traffic.
 
-There must also exist a .zmp file that matches the name of the chosen [`SUBMODEL`](#submodel)
-and zone system of the network.
+There are 13 different input vector files in `2018_zonedata` from `.car` to `.wrk`.
+In the `2018_zonedata` directory, there must also exist a .zmp file that matches
+the name of the chosen [`SUBMODEL`](#submodel),
+which maps the data to the zone system of the network.
+
+`Matrices` contains `.omx` files for demand, external traffic and freight traffic.
+The matrices may have missing zones (compared to the network), but cannot have extra zones.
 
 ### `FORECAST_DATA_PATH`
 
@@ -103,8 +106,10 @@ and zone system of the network.
 ### `LONG_DIST_DEMAND_FORECAST`
 
 If 'calc', runs assigment with free-flow speed and calculates demand for long-distance trips.
-If 'base', takes long-distance trips from base matrices.
+If 'base', takes long-distance trips from [base matrices](#baseline_data_path).
 If path, takes long-distance trips from that path.
+The zone system of the long-distance trips in path must match the baseline data
+in `2018_zonedata` directory.
 
 ### `FREIGHT_MATRIX_PATH`
 

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -70,11 +70,13 @@ If you are trying the test model, try
 `"C:\\FILL_YOUR_PATH\\model-system\\Scripts\\tests\\test_data\\Base_input_data"`.
 If you are trying another model, fill in whatever the path is.
 
-There should be two directiories under the path: `2018_zonedata` and `base_matrices`.
+There should be two directiories under the path: `2018_zonedata` and `Matrices`.
 The names of these directories are hardcoded.
-There are 10 different input vector files in `2018_zonedata` from `.car` to `.wrk`.
-`base_matrices` contains `.omx` and `.txt` files for costs, demand, external
-traffic and freight traffic.
+There are 13 different input vector files in `2018_zonedata` from `.car` to `.wrk`.
+`Matrices` contains `.omx` files for demand, external traffic and freight traffic.
+
+There must also exist a .zmp file that matches the name of the chosen [`SUBMODEL`](#submodel)
+and zone system of the network.
 
 ### `FORECAST_DATA_PATH`
 
@@ -86,16 +88,27 @@ If you are trying the test model, try
 `"C:\\FILL_YOUR_PATH\\model-system\\Scripts\\tests\\test_data\\Scenario_input_data\\2030_test"`.
 If you are trying another model, fill in whatever the path is.
 
-There should be 9 or 10 different input vector files in your forecast data path.
+There should be 12 or 13 different input vector files in your forecast data path.
 File extensions are similar to your `BASELINE_DATA_PATH\\2018_zonedata` files.
-The file `.car` is optional (?).
+The file `.car` is optional.
 
-In the .ext file there must be a value line for every external zone in use
-(i.e. centroids 31000…31999 In the network).
-In all other files (excluding files .cco, .tco and .trk) there must be a value
-line for every internal zone in use (i.e. centroids 1…30999 In the network).
+In all files, excluding files .cco, .tco and .trk, there must be a value
+line for every internal zone in use.
 It means that if there are no inhabitants, workplaces, parking costs etc. in
 some zone a zero value line instead of a missing line must be used.
+
+There must also exist a .zmp file that matches the name of the chosen [`SUBMODEL`](#submodel)
+and zone system of the network.
+
+### `LONG_DIST_DEMAND_FORECAST`
+
+If 'calc', runs assigment with free-flow speed and calculates demand for long-distance trips.
+If 'base', takes long-distance trips from base matrices.
+If path, takes long-distance trips from that path.
+
+### `FREIGHT_MATRIX_PATH`
+
+If specified, take freight demand matrices from path.
 
 ### `ITERATION_COUNT`
 
@@ -122,13 +135,7 @@ flags are separated by commas (e.g., `"OPTIONAL_FLAGS": ["RUN_AGENT_SIMULATION",
 
 Using this flag runs only end assignment of base demand matrices.
 
-### `FREE_FLOW_ASSIGNMENT`
-
-Using this flag runs assigment with free flow speed.
-Only one time period "vrk" is assigned.
-Forces the number of iterations to one, as speeds will not change.
-
-### `STORED_SPEED_ASSIGNMENT`
+#### `STORED_SPEED_ASSIGNMENT`
 
 Using this flag runs assigment with stored (fixed) speed.
 Forces the number of iterations to one, as speeds will not change.
@@ -155,7 +162,3 @@ periods will be saved to EMME project Database folder.
 
 Transit assignment in EMME stores large files which are used for assignment analyses.
 If activated, these files will be deleted after the model run.
-
-#### `USE_FIXED_TRANSIT_COST`
-
-If set, pre-calculated transit costs are taken from the Results folder.

--- a/Scripts/demand/external.py
+++ b/Scripts/demand/external.py
@@ -41,21 +41,3 @@ class ExternalModel:
             "demand_share": demand_share["external"]
         }
         self.purpose = Purpose(spec, zone_data)
-
-    def calc_external(self, mode: str, internal_trips: pandas.Series) -> Demand:
-        """Calculate external traffic.
-
-        Parameters
-        ----------
-        mode : str
-            Travel mode (car/transit/truck/trailer_truck)
-        internal_trips : pandas.Series
-            Sums of all (intra-area) trips to and frome zones
-        
-        Return
-        ------
-        Demand
-            Matrix of whole day trips from external to internal zones
-        """
-        mtx = pandas.DataFrame(0, self.all_zone_numbers, self.growth.index)
-        return Demand(self.purpose, mode, mtx.to_numpy().T)

--- a/Scripts/dev-config.json
+++ b/Scripts/dev-config.json
@@ -12,6 +12,7 @@
     "FIRST_MATRIX_ID": 100,
     "BASELINE_DATA_PATH": "C:\\XXX\\Lahtodata",
     "FORECAST_DATA_PATH": "C:\\XXX\\Ennusteskenaarioiden_syottotiedot\\2017",
+    "LONG_DIST_DEMAND_FORECAST": "base",
     "ITERATION_COUNT": 15,
     "MAX_GAP": 1.0,
     "REL_GAP": 0.01,

--- a/Scripts/lem_validate_inputfiles.py
+++ b/Scripts/lem_validate_inputfiles.py
@@ -57,7 +57,9 @@ def main(args):
         raise ValueError(msg)
 
     zone_numbers: Dict[str, numpy.array] = {}
-    time_periods = ["vrk"] if args.free_flow_assignment else param.time_periods
+    calculate_long_dist_demand = args.long_dist_demand_forecast == "calc"
+    time_periods = (["vrk"] if calculate_long_dist_demand
+        else param.time_periods)
 
     # Check scenario based input data
     log.info("Checking base zonedata & scenario-based input data...")
@@ -75,8 +77,7 @@ def main(args):
                 log.error(msg)
                 raise NameError(msg)
             assignment_model = MockAssignmentModel(
-                MatrixData(mock_result_path), args.free_flow_assignment,
-                time_periods)
+                MatrixData(mock_result_path), time_periods=time_periods)
             zone_numbers[args.submodel[i]] = assignment_model.zone_numbers
         else:
             if not os.path.isfile(emp_path):
@@ -165,7 +166,7 @@ def main(args):
                 base_matrices_path)
             log.error(msg)
             raise ValueError(msg)
-        if not args.free_flow_assignment:
+        if not calculate_long_dist_demand:
             matrixdata = MatrixData(base_matrices_path)
             for tp in time_periods:
                 with matrixdata.open("demand", tp, zone_numbers[submodel]) as mtx:
@@ -209,10 +210,13 @@ if __name__ == "__main__":
         default=config.LOG_FORMAT,
     )
     parser.add_argument(
-        "-f", "--free-flow-assignment",
-        action="store_true",
-        default=config.FREE_FLOW_ASSIGNMENT,
-        help="Using this flag runs assigment with free flow speed."
+        "-f", "--long-dist-demand-forecast",
+        type=str,
+        default=config.LONG_DIST_DEMAND_FORECAST,
+        help=("If 'calc', runs assigment with free-flow speed and "
+              + "calculates demand for long-distance trips. "
+              + "If 'base', takes long-distance trips from base matrices. "
+              + "If path, takes long-distance trips from that path.")
     )
     parser.add_argument(
         "--do-not-use-emme",

--- a/Scripts/tests/integration/test_helmet_validation.py
+++ b/Scripts/tests/integration/test_helmet_validation.py
@@ -15,7 +15,7 @@ class Args:
     results_path = TEST_DATA_PATH / "Results"
     scenario_name = "test"
     do_not_use_emme = True
-    free_flow_assignment = False
+    long_dist_demand_forecast = None
     submodel = ["uusimaa"]
 
 

--- a/Scripts/utils/config.py
+++ b/Scripts/utils/config.py
@@ -56,7 +56,8 @@ class Config:
         self.FIRST_SCENARIO_ID = None
         self.FIRST_MATRIX_ID = None
         self.END_ASSIGNMENT_ONLY = False
-        self.FREE_FLOW_ASSIGNMENT = False
+        self.LONG_DIST_DEMAND_FORECAST = None
+        self.FREIGHT_MATRIX_PATH = None
         self.STORED_SPEED_ASSIGNMENT = False
         self.RUN_AGENT_SIMULATION = False
         self.DO_NOT_USE_EMME = False


### PR DESCRIPTION
Added:
`--long-dist-demand-forecast`: "If `"calc"`, runs assigment with free-flow speed and calculates demand for long-distance trips. If `"base"`, takes long-distance trips from base matrices. If path, takes long-distance trips from that path."
`--freight-matrix-path`: "If specified, take freight demand matrices from path."

Removed:
`--free-flow-assignment`: This is replaced by `--long-dist-demand-forecast`

FYI: @SelinaMT @Konnde 