### PR TITLE
Implement traversal analysis

### DIFF
--- a/Scripts/assignment/emme_bindings/emme_project.py
+++ b/Scripts/assignment/emme_bindings/emme_project.py
@@ -77,6 +77,8 @@ class EmmeProject:
             "inro.emme.transit_assignment.extended.matrix_results")
         self.network_results = self.modeller.tool(
             "inro.emme.transit_assignment.extended.network_results")
+        self.traversal_analysis = self.modeller.tool(
+            "inro.emme.transit_assignment.extended.traversal_analysis")
         self.create_extra_attribute = self.modeller.tool(
             "inro.emme.data.extra_attribute.create_extra_attribute")
     

--- a/Scripts/assignment/freight_assignment.py
+++ b/Scripts/assignment/freight_assignment.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import utils.log as log
 import parameters.assignment as param
 from assignment.assignment_period import AssignmentPeriod
@@ -46,6 +48,21 @@ class FreightAssignmentPeriod(AssignmentPeriod):
             spec["on_links"]["aux_transit_volumes"] = '@a_' + attr_name
             self.emme_project.network_results(
                 spec, self.emme_scenario, ass_class)
+
+    def output_traversal_matrix(self, output_path: Path):
+        spec = {
+            "type": "EXTENDED_TRANSIT_TRAVERSAL_ANALYSIS",
+            "portion_of_path": "COMPLETE",
+            "gates_by_trip_component": {
+                "aux_transit": "@freight_gate",
+            },
+        }
+        for ass_class in param.freight_modes:
+            output_file = output_path / f"{ass_class}.txt"
+            spec["analyzed_demand"] = self.emme_matrices[ass_class]["demand"]
+            self.emme_project.traversal_analysis(
+                spec, output_file, append_to_output_file=False,
+                scenario=self.emme_scenario, class_name=ass_class)
 
     def _set_freight_vdfs(self):
         network = self.emme_scenario.get_network()


### PR DESCRIPTION
This should work for both sparser municipality-center network and for the full network. If run on the municipality-center network, some municipalities will have both the centroid and the freight terminal in the same zone number. In this case the demand on the matrix diagonal should be dis-aggregated according to some special rule.