### PR TITLE
Update long distance estimation with LOS data from 2016

### DIFF
--- a/Scripts/parameters/demand/hb_business_long.json
+++ b/Scripts/parameters/demand/hb_business_long.json
@@ -132,47 +132,47 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.7201
+                "logsum": 0.72034
             },
             "individual_dummy": {}
         },
         "train": {
-            "constant": -0.93174,
+            "constant": -0.9327,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.7201
+                "logsum": 0.72034
             },
             "individual_dummy": {}
         },
         "long_d_bus": {
-            "constant": -1.24571,
+            "constant": -1.24644,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.7201
+                "logsum": 0.72034
             },
             "individual_dummy": {}
         },
         "car_work": {
-            "constant": 1.32378,
+            "constant": 1.32173,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.7201
+                "logsum": 0.72034
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -1.19211,
+            "constant": -1.19342,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.7201
+                "logsum": 0.72034
             },
             "individual_dummy": {}
         }

--- a/Scripts/parameters/demand/hb_leisure_long.json
+++ b/Scripts/parameters/demand/hb_leisure_long.json
@@ -71,8 +71,8 @@
             },
             "attraction_size": {
                 "population": 1,
-                "hospitality": 439.41311,
-                "area_leisure": 0.85157
+                "hospitality": 432.66337,
+                "area_leisure": 0.84113
             }
         },
         "train": {
@@ -86,8 +86,8 @@
             },
             "attraction_size": {
                 "population": 1,
-                "hospitality": 439.41311,
-                "area_leisure": 0.85157
+                "hospitality": 432.66337,
+                "area_leisure": 0.84113
             }
         },
         "long_d_bus": {
@@ -101,14 +101,14 @@
             },
             "attraction_size": {
                 "population": 1,
-                "hospitality": 439.41311,
-                "area_leisure": 0.85157
+                "hospitality": 432.66337,
+                "area_leisure": 0.84113
             }
         },
         "car_leisure": {
             "attraction": {},
             "impedance": {
-                "time": -0.00239,
+                "time": -0.0024,
                 "cost": -0.01291
             },
             "log": {
@@ -116,8 +116,8 @@
             },
             "attraction_size": {
                 "population": 1,
-                "hospitality": 439.41311,
-                "area_leisure": 0.85157
+                "hospitality": 432.66337,
+                "area_leisure": 0.84113
             }
         },
         "car_pax": {
@@ -130,8 +130,8 @@
             },
             "attraction_size": {
                 "population": 1,
-                "hospitality": 439.41311,
-                "area_leisure": 0.85157
+                "hospitality": 432.66337,
+                "area_leisure": 0.84113
             }
         }
     },
@@ -142,47 +142,47 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.94086
+                "logsum": 0.93947
             },
             "individual_dummy": {}
         },
         "train": {
-            "constant": -0.46056,
+            "constant": -0.45543,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.94086
+                "logsum": 0.93947
             },
             "individual_dummy": {}
         },
         "long_d_bus": {
-            "constant": 0.70213,
+            "constant": 0.70966,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.94086
+                "logsum": 0.93947
             },
             "individual_dummy": {}
         },
         "car_leisure": {
-            "constant": 1.75085,
+            "constant": 1.76274,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.94086
+                "logsum": 0.93947
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": 1.41261,
+            "constant": 1.42098,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.94086
+                "logsum": 0.93947
             },
             "individual_dummy": {}
         }

--- a/Scripts/parameters/demand/hb_work_long.json
+++ b/Scripts/parameters/demand/hb_work_long.json
@@ -63,8 +63,8 @@
         "airplane": {
             "attraction": {},
             "impedance": {
-                "time": -0.00063,
-                "cost": -0.02103
+                "time": -0.00062,
+                "cost": -0.03119
             },
             "log": {
                 "attraction_size": 1
@@ -76,8 +76,8 @@
         "train": {
             "attraction": {},
             "impedance": {
-                "time": -0.00118,
-                "cost": -0.02103
+                "time": -0.00095,
+                "cost": -0.03119
             },
             "log": {
                 "attraction_size": 1
@@ -89,8 +89,8 @@
         "long_d_bus": {
             "attraction": {},
             "impedance": {
-                "time": -0.00137,
-                "cost": -0.02103
+                "time": -0.00089,
+                "cost": -0.03119
             },
             "log": {
                 "attraction_size": 1
@@ -102,8 +102,8 @@
         "car_work": {
             "attraction": {},
             "impedance": {
-                "time": -0.00239,
-                "cost": -0.02103
+                "time": -0.00002,
+                "cost": -0.03119
             },
             "log": {
                 "attraction_size": 1
@@ -115,7 +115,7 @@
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.00407
+                "time": -0.00006
             },
             "log": {
                 "attraction_size": 1
@@ -132,47 +132,47 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.88356
+                "logsum": 0.71006
             },
             "individual_dummy": {}
         },
         "train": {
-            "constant": -1.69419,
+            "constant": -3.22389,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.88356
+                "logsum": 0.71006
             },
             "individual_dummy": {}
         },
         "long_d_bus": {
-            "constant": -3.04595,
+            "constant": -5.1085,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.88356
+                "logsum": 0.71006
             },
             "individual_dummy": {}
         },
         "car_work": {
-            "constant": -0.98759,
+            "constant": -2.69799,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.88356
+                "logsum": 0.71006
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -4.48273,
+            "constant": -8.32734,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.88356
+                "logsum": 0.71006
             },
             "individual_dummy": {}
         }


### PR DESCRIPTION
Primary survey data source is collected in 2016 and therefore LOS data should represent same base year. Until now estimation LOS price data has been collected in 2023. Here we update estimation with input data representing year 2016:
* Car cost and transit cost are transferred from 2023 to 2016 using consumer price indexes. 
* Transit time is updated with SYKE network data from year 2018.