### PR TITLE
Embed parking cost in car cost matrix

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -74,11 +74,6 @@ class Purpose:
     def dest_interval(self):
         return slice(0, self.zone_data.nr_zones)
     
-    def add_destination_cost(self, mtx, vector):
-        """Add zonedata to matrix. """
-        mtx = numpy.add(mtx, vector)
-        return mtx
-
     def transform_impedance(self, impedance):
         """Perform transformation from time period dependent matrices
         to aggregate impedance matrices for specific travel purpose.
@@ -144,15 +139,11 @@ class Purpose:
                 day_imp[mode][mtx_type] *= p
                 # Add parking time and cost to LOS matrix
                 if mtx_type == "time" and "car" in mode:
-                    day_imp[mode][mtx_type] = self.add_destination_cost(
-                        day_imp[mode][mtx_type], 
-                        self.zone_data["park_time"].values)
+                    day_imp[mode][mtx_type] += self.zone_data["park_time"].values
                 if mtx_type == "cost" and "car" in mode:
-                    park_cost = (activity_time[self.name] * 
-                                 share_paying[self.name] * 
-                                 self.zone_data["park_cost"].values)
-                    day_imp[mode][mtx_type] = self.add_destination_cost(
-                        day_imp[mode][mtx_type], park_cost)
+                    day_imp[mode][mtx_type] += (activity_time[self.name] * 
+                                                share_paying[self.name] * 
+                                                self.zone_data["park_cost"].values)
         return day_imp
 
 

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -618,3 +618,27 @@ station_ids = {
     "metro": 13,
     "train": 14,
 }
+
+activity_time = {
+    "hb_work": 7.2,
+    "hb_edu_upsec": 5.2,
+    "hb_edu_higher": 4.6,
+    "hb_grocery": 0.6,
+    "hb_other_shop": 1.1,
+    "hb_leisure": 2.0,
+    "hb_sport": 1.5,
+    "hb_visit": 2.5,
+    "ob_other": 1.4
+}
+
+share_paying = {
+    "hb_work": 0.50,
+    "hb_edu_upsec": 0.30,
+    "hb_edu_higher": 0.30,
+    "hb_grocery": 1.00,
+    "hb_other_shop": 0.15,
+    "hb_leisure": 1.00,
+    "hb_sport": 0.00,
+    "hb_visit": 0.75,
+    "ob_other": 0.00
+} 

--- a/Scripts/parameters/demand/hb_edu_higher.json
+++ b/Scripts/parameters/demand/hb_edu_higher.json
@@ -106,13 +106,12 @@
     "destination_choice": {
         "car_work": {
             "attraction": {
-                "park_cost": -0.17221,
-                "park_time": -0.03699,
-                "within_zone_time": -0.03699
+                "park_time": -0.03651,
+                "within_zone_time": -0.03651
             },
             "impedance": {
-                "time": -0.03699,
-                "cost": -0.11405
+                "time": -0.03651,
+                "cost": -0.11971
             },
             "log": {
                 "attraction_size": 1
@@ -123,11 +122,11 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.0545,
-                "within_zone_time": -0.0545
+                "park_time": -0.0548,
+                "within_zone_time": -0.0548
             },
             "impedance": {
-                "time": -0.0545
+                "time": -0.0548
             },
             "log": {
                 "attraction_size": 1
@@ -141,8 +140,8 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.01689,
-                "cost": -0.11405
+                "time": -0.01683,
+                "cost": -0.11971
             },
             "log": {
                 "attraction_size": 1
@@ -153,10 +152,10 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.25425
+                "within_zone_dist": -0.2543
             },
             "impedance": {
-                "dist": -0.25425
+                "dist": -0.2543
             },
             "log": {
                 "attraction_size": 1
@@ -167,10 +166,10 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.45012
+                "within_zone_dist": -0.45023
             },
             "impedance": {
-                "dist": -0.45012
+                "dist": -0.45023
             },
             "log": {
                 "attraction_size": 1
@@ -182,46 +181,46 @@
     },
     "mode_choice": {
         "car_work": {
-            "constant": -3.36335,
+            "constant": -3.37599,
             "generation": {
-                "car_density": 1.99318
+                "car_density": 2.00948
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1.0
+                "logsum": 1.01526
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -3.56507,
+            "constant": -3.56024,
             "generation": {
-                "car_density": -0.29302
+                "car_density": -0.29148
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1.0
+                "logsum": 1.01526
             },
             "individual_dummy": {}
         },
         "transit_work": {
-            "constant": -1.50081,
+            "constant": -1.49397,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1.0
+                "logsum": 1.01526
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -1.37047,
+            "constant": -1.37106,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1.0
+                "logsum": 1.01526
             },
             "individual_dummy": {}
         },
@@ -231,7 +230,7 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1.0
+                "logsum": 1.01526
             },
             "individual_dummy": {}
         }

--- a/Scripts/parameters/demand/hb_edu_upsec.json
+++ b/Scripts/parameters/demand/hb_edu_upsec.json
@@ -106,13 +106,12 @@
     "destination_choice": {
         "car_work": {
             "attraction": {
-                "park_cost": -0.37268,
-                "park_time": -0.05531,
-                "within_zone_time": -0.05531
+                "park_time": -0.05551,
+                "within_zone_time": -0.05551
             },
             "impedance": {
-                "time": -0.05531,
-                "cost": -0.27005
+                "time": -0.05551,
+                "cost": -0.26768
             },
             "log": {
                 "attraction_size": 1
@@ -123,11 +122,11 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.10002,
-                "within_zone_time": -0.10002
+                "park_time": -0.1,
+                "within_zone_time": -0.1
             },
             "impedance": {
-                "time": -0.10002
+                "time": -0.1
             },
             "log": {
                 "attraction_size": 1
@@ -141,8 +140,8 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.0163,
-                "cost": -0.27005
+                "time": -0.01633,
+                "cost": -0.26768
             },
             "log": {
                 "attraction_size": 1
@@ -153,10 +152,10 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.41308
+                "within_zone_dist": -0.41302
             },
             "impedance": {
-                "dist": -0.41308
+                "dist": -0.41302
             },
             "log": {
                 "attraction_size": 1
@@ -167,10 +166,10 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.68326
+                "within_zone_dist": -0.68313
             },
             "impedance": {
-                "dist": -0.68326
+                "dist": -0.68313
             },
             "log": {
                 "attraction_size": 1
@@ -182,46 +181,46 @@
     },
     "mode_choice": {
         "car_work": {
-            "constant": -5.44978,
+            "constant": -5.43365,
             "generation": {
-                "car_density": 6.3151
+                "car_density": 6.29022
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5863
+                "logsum": 0.58674
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -3.63655,
+            "constant": -3.63662,
             "generation": {
-                "car_density": 2.35013
+                "car_density": 2.35186
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5863
+                "logsum": 0.58674
             },
             "individual_dummy": {}
         },
         "transit_work": {
-            "constant": -0.99404,
+            "constant": -0.99904,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5863
+                "logsum": 0.58674
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -0.89486,
+            "constant": -0.89467,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5863
+                "logsum": 0.58674
             },
             "individual_dummy": {}
         },
@@ -231,7 +230,7 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5863
+                "logsum": 0.58674
             },
             "individual_dummy": {}
         }

--- a/Scripts/parameters/demand/hb_grocery.json
+++ b/Scripts/parameters/demand/hb_grocery.json
@@ -102,35 +102,34 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_cost": -0.26728,
-                "park_time": -0.10805,
-                "within_zone_time": -0.10805
+                "park_time": -0.10685,
+                "within_zone_time": -0.10685
             },
             "impedance": {
-                "time": -0.10805,
-                "cost": -0.20127
+                "time": -0.10685,
+                "cost": -0.21471
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 45.84564,
+                "shop": 45.69368,
                 "population": 1
             }
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.1194,
-                "within_zone_time": -0.1194
+                "park_time": -0.11946,
+                "within_zone_time": -0.11946
             },
             "impedance": {
-                "time": -0.1194
+                "time": -0.11946
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 45.84564,
+                "shop": 45.69368,
                 "population": 1
             }
         },
@@ -139,90 +138,90 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.04546,
-                "cost": -0.20127
+                "time": -0.0453,
+                "cost": -0.21471
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 45.84564,
+                "shop": 45.69368,
                 "population": 1
             }
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.36855
+                "within_zone_dist": -0.36835
             },
             "impedance": {
-                "dist": -0.36855
+                "dist": -0.36835
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 45.84564,
+                "shop": 45.69368,
                 "population": 1
             }
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.71431
+                "within_zone_dist": -0.71403
             },
             "impedance": {
-                "dist": -0.71431
+                "dist": -0.71403
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 45.84564,
+                "shop": 45.69368,
                 "population": 1
             }
         }
     },
     "mode_choice": {
         "car_leisure": {
-            "constant": -3.43572,
+            "constant": -3.51433,
             "generation": {
-                "car_density": 6.66474
+                "car_density": 6.80767
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.77479
+                "logsum": 0.77277
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -4.80847,
+            "constant": -4.82479,
             "generation": {
-                "car_density": 5.88062
+                "car_density": 5.91664
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.77479
+                "logsum": 0.77277
             },
             "individual_dummy": {}
         },
         "transit_leisure": {
-            "constant": -1.67496,
+            "constant": -1.62545,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.77479
+                "logsum": 0.77277
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -2.57266,
+            "constant": -2.57622,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.77479
+                "logsum": 0.77277
             },
             "individual_dummy": {}
         },
@@ -232,7 +231,7 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.77479
+                "logsum": 0.77277
             },
             "individual_dummy": {}
         }

--- a/Scripts/parameters/demand/hb_leisure.json
+++ b/Scripts/parameters/demand/hb_leisure.json
@@ -102,36 +102,35 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_cost": -0.33804,
-                "park_time": -0.06991,
-                "within_zone_time": -0.06991
+                "park_time": -0.06164,
+                "within_zone_time": -0.06164
             },
             "impedance": {
-                "time": -0.06991,
-                "cost": -0.06857
+                "time": -0.06164,
+                "cost": -0.12997
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "hospitality": 1,
-                "recreation": 1.31192
+                "recreation": 1.31805
             }
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.07628,
-                "within_zone_time": -0.07628
+                "park_time": -0.07647,
+                "within_zone_time": -0.07647
             },
             "impedance": {
-                "time": -0.07628
+                "time": -0.07647
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "hospitality": 1,
-                "recreation": 1.31192
+                "recreation": 1.31805
             }
         },
         "transit_leisure": {
@@ -139,90 +138,90 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.02216,
-                "cost": -0.06857
+                "time": -0.01988,
+                "cost": -0.12997
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "hospitality": 1,
-                "recreation": 1.31192
+                "recreation": 1.31805
             }
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.18454
+                "within_zone_dist": -0.18426
             },
             "impedance": {
-                "dist": -0.18454
+                "dist": -0.18426
             },
             "log": {
                 "attraction_size": 1.0
             },
             "attraction_size": {
                 "hospitality": 1,
-                "recreation": 1.31192
+                "recreation": 1.31805
             }
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.52616
+                "within_zone_dist": -0.52639
             },
             "impedance": {
-                "dist": -0.52616
+                "dist": -0.52639
             },
             "log": {
                 "attraction_size": 1.0
             },
             "attraction_size": {
                 "hospitality": 1,
-                "recreation": 1.31192
+                "recreation": 1.31805
             }
         }
     },
     "mode_choice": {
         "car_leisure": {
-            "constant": -2.37273,
+            "constant": -2.61326,
             "generation": {
-                "car_density": 4.58709
+                "car_density": 4.92192
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.71175
+                "logsum": 0.70031
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -2.83173,
+            "constant": -2.87048,
             "generation": {
-                "car_density": 4.30302
+                "car_density": 4.43401
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.71175
+                "logsum": 0.70031
             },
             "individual_dummy": {}
         },
         "transit_leisure": {
-            "constant": -2.10579,
+            "constant": -1.99498,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.71175
+                "logsum": 0.70031
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -2.34255,
+            "constant": -2.35663,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.71175
+                "logsum": 0.70031
             },
             "individual_dummy": {}
         },
@@ -232,7 +231,7 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.71175
+                "logsum": 0.70031
             },
             "individual_dummy": {}
         }

--- a/Scripts/parameters/demand/hb_other_shop.json
+++ b/Scripts/parameters/demand/hb_other_shop.json
@@ -102,13 +102,12 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_cost": -0.02701,
-                "park_time": -0.06119,
-                "within_zone_time": -0.06119
+                "park_time": -0.06117,
+                "within_zone_time": -0.06117
             },
             "impedance": {
-                "time": -0.06119,
-                "cost": -0.167
+                "time": -0.06117,
+                "cost": -0.16709
             },
             "log": {
                 "attraction_size": 1
@@ -138,7 +137,7 @@
             },
             "impedance": {
                 "time": -0.02944,
-                "cost": -0.167
+                "cost": -0.16709
             },
             "log": {
                 "attraction_size": 1
@@ -163,10 +162,10 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.56823
+                "within_zone_dist": -0.56824
             },
             "impedance": {
-                "dist": -0.56823
+                "dist": -0.56824
             },
             "log": {
                 "attraction_size": 1
@@ -178,46 +177,46 @@
     },
     "mode_choice": {
         "car_leisure": {
-            "constant": -2.61387,
+            "constant": -2.61375,
             "generation": {
-                "car_density": 4.50219
+                "car_density": 4.50163
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.74892
+                "logsum": 0.74891
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -3.50766,
+            "constant": -3.50763,
             "generation": {
-                "car_density": 3.63874
+                "car_density": 3.63862
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.74892
+                "logsum": 0.74891
             },
             "individual_dummy": {}
         },
         "transit_leisure": {
-            "constant": -0.95419,
+            "constant": -0.95399,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.74892
+                "logsum": 0.74891
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -2.4868,
+            "constant": -2.48682,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.74892
+                "logsum": 0.74891
             },
             "individual_dummy": {}
         },
@@ -227,7 +226,7 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.74892
+                "logsum": 0.74891
             },
             "individual_dummy": {}
         }

--- a/Scripts/parameters/demand/hb_sport.json
+++ b/Scripts/parameters/demand/hb_sport.json
@@ -102,20 +102,19 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_cost": -0.00842,
-                "park_time": -0.04959,
-                "within_zone_time": -0.04959
+                "park_time": -0.0497,
+                "within_zone_time": -0.0497
             },
             "impedance": {
-                "time": -0.04959,
-                "cost": -0.25634
+                "time": -0.0497,
+                "cost": -0.25569
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "sports_in": 1,
-                "sports_out": 0.13997
+                "sports_out": 0.14002
             }
         },
         "car_pax": {
@@ -131,7 +130,7 @@
             },
             "attraction_size": {
                 "sports_in": 1,
-                "sports_out": 0.13997
+                "sports_out": 0.14002
             }
         },
         "transit_leisure": {
@@ -139,90 +138,90 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.03067,
-                "cost": -0.25634
+                "time": -0.03069,
+                "cost": -0.25569
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "sports_in": 1,
-                "sports_out": 0.13997
+                "sports_out": 0.14002
             }
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.24291
+                "within_zone_dist": -0.2429
             },
             "impedance": {
-                "dist": -0.24291
+                "dist": -0.2429
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "sports_in": 1,
-                "sports_out": 0.13997
+                "sports_out": 0.14002
             }
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.36052
+                "within_zone_dist": -0.36051
             },
             "impedance": {
-                "dist": -0.36052
+                "dist": -0.36051
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "sports_in": 1,
-                "sports_out": 0.13997
+                "sports_out": 0.14002
             }
         }
     },
     "mode_choice": {
         "car_leisure": {
-            "constant": -2.29837,
+            "constant": -2.29927,
             "generation": {
-                "car_density": 1.43332
+                "car_density": 1.43401
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.75897
+                "logsum": 0.75895
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -2.60898,
+            "constant": -2.60925,
             "generation": {
-                "car_density": 1.51967
+                "car_density": 1.52362
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.75897
+                "logsum": 0.75895
             },
             "individual_dummy": {}
         },
         "transit_leisure": {
-            "constant": -1.36875,
+            "constant": -1.37071,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.75897
+                "logsum": 0.75895
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -1.83052,
+            "constant": -1.83054,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.75897
+                "logsum": 0.75895
             },
             "individual_dummy": {}
         },
@@ -232,7 +231,7 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.75897
+                "logsum": 0.75895
             },
             "individual_dummy": {}
         }

--- a/Scripts/parameters/demand/hb_visit.json
+++ b/Scripts/parameters/demand/hb_visit.json
@@ -100,133 +100,132 @@
         ]
     },
     "destination_choice": {
-      "car_leisure": {
-          "attraction": {
-              "park_cost": -0.11934,
-              "park_time": -0.04445,
-              "within_zone_time": -0.04445
-          },
-          "impedance": {
-              "time": -0.04445,
-              "cost": -0.06369
-          },
-          "log": {
-              "attraction_size": 1
-          },
-          "attraction_size": {
-              "population": 1
-          }
-      },
-      "car_pax": {
-          "attraction": {
-              "park_time": -0.0496,
-              "within_zone_time": -0.0496
-          },
-          "impedance": {
-              "time": -0.0496
-          },
-          "log": {
-              "attraction_size": 1
-          },
-          "attraction_size": {
-              "population": 1
-          }
-      },
-      "transit_leisure": {
-          "attraction": {
-            "within_zone_inf": -1
-          },
-          "impedance": {
-              "time": -0.01426,
-              "cost": -0.06369
-          },
-          "log": {
-              "attraction_size": 1
-          },
-          "attraction_size": {
-              "population": 1
-          }
-      },
-      "bike": {
-          "attraction": {
-              "within_zone_dist": -0.25663
-          },
-          "impedance": {
-              "dist": -0.25663
-          },
-          "log": {
-              "attraction_size": 1
-          },
-          "attraction_size": {
-              "population": 1
-          }
-      },
-      "walk": {
-          "attraction": {
-              "within_zone_dist": -0.43947
-          },
-          "impedance": {
-              "dist": -0.43947
-          },
-          "log": {
-              "attraction_size": 1
-          },
-          "attraction_size": {
-              "population": 1
-          }
-      }
-  },
-  "mode_choice": {
-      "car_leisure": {
-          "constant": -1.09832,
-          "generation": {},
-          "attraction": {},
-          "impedance": {},
-          "log": {
-              "logsum": 0.59639
-          },
-          "individual_dummy": {}
-      },
-      "car_pax": {
-          "constant": -2.24815,
-          "generation": {},
-          "attraction": {},
-          "impedance": {},
-          "log": {
-              "logsum": 0.59639
-          },
-          "individual_dummy": {}
-      },
-      "transit_leisure": {
-          "constant": -3.78789,
-          "generation": {},
-          "attraction": {},
-          "impedance": {},
-          "log": {
-              "logsum": 0.59639
-          },
-          "individual_dummy": {}
-      },
-      "bike": {
-          "constant": -1.77677,
-          "generation": {},
-          "attraction": {},
-          "impedance": {},
-          "log": {
-              "logsum": 0.59639
-          },
-          "individual_dummy": {}
-      },
-      "walk": {
-          "constant": 0,
-          "generation": {},
-          "attraction": {},
-          "impedance": {},
-          "log": {
-              "logsum": 0.59639
-          },
-          "individual_dummy": {}
-      }
+        "car_leisure": {
+            "attraction": {
+                "park_time": -0.04444,
+                "within_zone_time": -0.04444
+            },
+            "impedance": {
+                "time": -0.04444,
+                "cost": -0.06415
+            },
+            "log": {
+                "attraction_size": 1
+            },
+            "attraction_size": {
+                "population": 1
+            }
+        },
+        "car_pax": {
+            "attraction": {
+                "park_time": -0.04959,
+                "within_zone_time": -0.04959
+            },
+            "impedance": {
+                "time": -0.04959
+            },
+            "log": {
+                "attraction_size": 1
+            },
+            "attraction_size": {
+                "population": 1
+            }
+        },
+        "transit_leisure": {
+            "attraction": {
+                "within_zone_inf": -1
+            },
+            "impedance": {
+                "time": -0.01424,
+                "cost": -0.06415
+            },
+            "log": {
+                "attraction_size": 1
+            },
+            "attraction_size": {
+                "population": 1
+            }
+        },
+        "bike": {
+            "attraction": {
+                "within_zone_dist": -0.25651
+            },
+            "impedance": {
+                "dist": -0.25651
+            },
+            "log": {
+                "attraction_size": 1
+            },
+            "attraction_size": {
+                "population": 1
+            }
+        },
+        "walk": {
+            "attraction": {
+                "within_zone_dist": -0.43911
+            },
+            "impedance": {
+                "dist": -0.43911
+            },
+            "log": {
+                "attraction_size": 1
+            },
+            "attraction_size": {
+                "population": 1
+            }
+        }
+    },
+    "mode_choice": {
+        "car_leisure": {
+            "constant": -1.10037,
+            "generation": {},
+            "attraction": {},
+            "impedance": {},
+            "log": {
+                "logsum": 0.59889
+            },
+            "individual_dummy": {}
+        },
+        "car_pax": {
+            "constant": -2.2473,
+            "generation": {},
+            "attraction": {},
+            "impedance": {},
+            "log": {
+                "logsum": 0.59889
+            },
+            "individual_dummy": {}
+        },
+        "transit_leisure": {
+            "constant": -3.77512,
+            "generation": {},
+            "attraction": {},
+            "impedance": {},
+            "log": {
+                "logsum": 0.59889
+            },
+            "individual_dummy": {}
+        },
+        "bike": {
+            "constant": -1.77158,
+            "generation": {},
+            "attraction": {},
+            "impedance": {},
+            "log": {
+                "logsum": 0.59889
+            },
+            "individual_dummy": {}
+        },
+        "walk": {
+            "constant": 0,
+            "generation": {},
+            "attraction": {},
+            "impedance": {},
+            "log": {
+                "logsum": 0.59889
+            },
+            "individual_dummy": {}
+        }
     },
     "demand_share": {
         "car_leisure": {

--- a/Scripts/parameters/demand/hb_work.json
+++ b/Scripts/parameters/demand/hb_work.json
@@ -102,13 +102,12 @@
     "destination_choice": {
         "car_work": {
             "attraction": {
-                "park_cost": -0.23379,
-                "park_time": -0.04361,
-                "within_zone_time": -0.04361
+                "park_time": -0.04333,
+                "within_zone_time": -0.04333
             },
             "impedance": {
-                "time": -0.04361,
-                "cost": -0.06237
+                "time": -0.04333,
+                "cost": -0.0643
             },
             "log": {
                 "attraction_size": 1
@@ -119,11 +118,11 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.06937,
-                "within_zone_time": -0.06937
+                "park_time": -0.06938,
+                "within_zone_time": -0.06938
             },
             "impedance": {
-                "time": -0.06937
+                "time": -0.06938
             },
             "log": {
                 "attraction_size": 1
@@ -137,8 +136,8 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.01677,
-                "cost": -0.06237
+                "time": -0.01669,
+                "cost": -0.0643
             },
             "log": {
                 "attraction_size": 1
@@ -149,10 +148,10 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.14853
+                "within_zone_dist": -0.14851
             },
             "impedance": {
-                "dist": -0.14853
+                "dist": -0.14851
             },
             "log": {
                 "attraction_size": 1
@@ -163,10 +162,10 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.39291
+                "within_zone_dist": -0.3929
             },
             "impedance": {
-                "dist": -0.39291
+                "dist": -0.3929
             },
             "log": {
                 "attraction_size": 1
@@ -178,46 +177,46 @@
     },
     "mode_choice": {
         "car_work": {
-            "constant": -1.13024,
+            "constant": -1.13709,
             "generation": {
-                "car_density": 2.95297
+                "car_density": 2.95883
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.96309
+                "logsum": 0.96207
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -2.91155,
+            "constant": -2.91394,
             "generation": {
-                "car_density": 3.40559
+                "car_density": 3.41772
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.96309
+                "logsum": 0.96207
             },
             "individual_dummy": {}
         },
         "transit_work": {
-            "constant": -0.50925,
+            "constant": -0.50553,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.96309
+                "logsum": 0.96207
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -0.86361,
+            "constant": -0.86316,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.96309
+                "logsum": 0.96207
             },
             "individual_dummy": {}
         },
@@ -227,7 +226,7 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.96309
+                "logsum": 0.96207
             },
             "individual_dummy": {}
         }

--- a/Scripts/parameters/demand/ob_other.json
+++ b/Scripts/parameters/demand/ob_other.json
@@ -108,38 +108,37 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_cost": -0.38234,
-                "park_time": -0.08521,
-                "within_zone_time": -0.08521
+                "park_time": -0.09693,
+                "within_zone_time": -0.09693
             },
             "impedance": {
-                "time": -0.08521,
-                "cost": -0.06608
+                "time": -0.09693,
+                "cost": -0.02288
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "shop": 1,
-                "recreation": 3.23484,
-                "hospitality": 3.8946
+                "recreation": 3.80936,
+                "hospitality": 4.10247
             }
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.07713,
-                "within_zone_time": -0.07713
+                "park_time": -0.07648,
+                "within_zone_time": -0.07648
             },
             "impedance": {
-                "time": -0.07713
+                "time": -0.07648
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "shop": 1,
-                "recreation": 3.23484,
-                "hospitality": 3.8946
+                "recreation": 3.80936,
+                "hospitality": 4.10247
             }
         },
         "transit_leisure": {
@@ -147,89 +146,89 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.01092,
-                "cost": -0.06608
+                "time": -0.01519,
+                "cost": -0.02288
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "shop": 1,
-                "recreation": 3.23484,
-                "hospitality": 3.8946
+                "recreation": 3.80936,
+                "hospitality": 4.10247
             }
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.51261
+                "within_zone_dist": -0.51661
             },
             "impedance": {
-                "dist": -0.51261
+                "dist": -0.51661
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "shop": 1,
-                "recreation": 3.23484,
-                "hospitality": 3.8946
+                "recreation": 3.80936,
+                "hospitality": 4.10247
             }
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.35038
+                "within_zone_dist": -0.3501
             },
             "impedance": {
-                "dist": -0.35038
+                "dist": -0.3501
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "shop": 1,
-                "recreation": 3.23484,
-                "hospitality": 3.8946
+                "recreation": 3.80936,
+                "hospitality": 4.10247
             }
         }
     },
     "mode_choice": {
         "car_leisure": {
-            "constant": -0.65874,
+            "constant": -0.38487,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6598
+                "logsum": 0.66708
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -1.2557,
+            "constant": -1.3429,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6598
+                "logsum": 0.66708
             },
             "individual_dummy": {}
         },
         "transit_leisure": {
-            "constant": -4.36487,
+            "constant": -4.07107,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6598
+                "logsum": 0.66708
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -2.29124,
+            "constant": -1.83562,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6598
+                "logsum": 0.66708
             },
             "individual_dummy": {}
         },
@@ -239,7 +238,7 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6598
+                "logsum": 0.66708
             },
             "individual_dummy": {}
         }

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -53,7 +53,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_work"] + model.mode_share[0]["car_leisure"],
-            0.23980001182734606)
+            0.25467787853321716)
         
         print("Model system test done")
     


### PR DESCRIPTION
For future work with cost damping, cost sharing and values-of-time it would beneficial to have only single cost parameter in utility function. This pull request joins parking cost within car cost matrix. Parking costs are included at the destination of the tour, as it is assumed individuals do not have to pay to park at home

Activity time is weighted mean from National Travel Survey.  Share paying for parking is deducted by initially estimating model with separate parking cost parameter and then calculating ratio of `parking cost/ car cost`. 

Testing of cost and time damping are built on this branch.

