### PR TITLE
Remove extra park time and loop all impedance matrices

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -137,13 +137,18 @@ class Purpose:
             for mtx_type in self.impedance_transform[mode]:
                 p = self.impedance_transform[mode][mtx_type]
                 day_imp[mode][mtx_type] *= p
+        for mode in day_imp:
+            for mtx_type in day_imp[mode]:
                 # Add parking time and cost to LOS matrix
                 if mtx_type == "time" and "car" in mode:
                     day_imp[mode][mtx_type] += self.zone_data["park_time"].values
                 if mtx_type == "cost" and "car" in mode:
-                    day_imp[mode][mtx_type] += (activity_time[self.name] * 
-                                                share_paying[self.name] * 
-                                                self.zone_data["park_cost"].values)
+                    try:
+                        day_imp[mode][mtx_type] += (activity_time[self.name] *
+                                                    share_paying[self.name] *
+                                                    self.zone_data["park_cost"].values)
+                    except KeyError:
+                        pass
         return day_imp
 
 

--- a/Scripts/parameters/demand/hb_edu_basic.json
+++ b/Scripts/parameters/demand/hb_edu_basic.json
@@ -84,7 +84,6 @@
     "destination_choice": {
         "car_pax": {
             "attraction": {
-                "park_time": -0.15066,
                 "within_zone_time": -0.15066
             },
             "impedance": {

--- a/Scripts/parameters/demand/hb_edu_higher.json
+++ b/Scripts/parameters/demand/hb_edu_higher.json
@@ -106,7 +106,6 @@
     "destination_choice": {
         "car_work": {
             "attraction": {
-                "park_time": -0.03651,
                 "within_zone_time": -0.03651
             },
             "impedance": {
@@ -122,7 +121,6 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.0548,
                 "within_zone_time": -0.0548
             },
             "impedance": {

--- a/Scripts/parameters/demand/hb_edu_upsec.json
+++ b/Scripts/parameters/demand/hb_edu_upsec.json
@@ -106,7 +106,6 @@
     "destination_choice": {
         "car_work": {
             "attraction": {
-                "park_time": -0.05551,
                 "within_zone_time": -0.05551
             },
             "impedance": {
@@ -122,7 +121,6 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.1,
                 "within_zone_time": -0.1
             },
             "impedance": {

--- a/Scripts/parameters/demand/hb_grocery.json
+++ b/Scripts/parameters/demand/hb_grocery.json
@@ -102,7 +102,6 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_time": -0.10685,
                 "within_zone_time": -0.10685
             },
             "impedance": {
@@ -119,7 +118,6 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.11946,
                 "within_zone_time": -0.11946
             },
             "impedance": {

--- a/Scripts/parameters/demand/hb_leisure.json
+++ b/Scripts/parameters/demand/hb_leisure.json
@@ -102,7 +102,6 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_time": -0.06164,
                 "within_zone_time": -0.06164
             },
             "impedance": {
@@ -119,7 +118,6 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.07647,
                 "within_zone_time": -0.07647
             },
             "impedance": {

--- a/Scripts/parameters/demand/hb_other_shop.json
+++ b/Scripts/parameters/demand/hb_other_shop.json
@@ -102,7 +102,6 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_time": -0.06117,
                 "within_zone_time": -0.06117
             },
             "impedance": {
@@ -118,7 +117,6 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.07787,
                 "within_zone_time": -0.07787
             },
             "impedance": {

--- a/Scripts/parameters/demand/hb_sport.json
+++ b/Scripts/parameters/demand/hb_sport.json
@@ -102,7 +102,6 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_time": -0.0497,
                 "within_zone_time": -0.0497
             },
             "impedance": {
@@ -119,7 +118,6 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.08225,
                 "within_zone_time": -0.08225
             },
             "impedance": {

--- a/Scripts/parameters/demand/hb_visit.json
+++ b/Scripts/parameters/demand/hb_visit.json
@@ -102,7 +102,6 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_time": -0.04444,
                 "within_zone_time": -0.04444
             },
             "impedance": {
@@ -118,7 +117,6 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.04959,
                 "within_zone_time": -0.04959
             },
             "impedance": {

--- a/Scripts/parameters/demand/hb_work.json
+++ b/Scripts/parameters/demand/hb_work.json
@@ -102,7 +102,6 @@
     "destination_choice": {
         "car_work": {
             "attraction": {
-                "park_time": -0.04333,
                 "within_zone_time": -0.04333
             },
             "impedance": {
@@ -118,7 +117,6 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.06938,
                 "within_zone_time": -0.06938
             },
             "impedance": {

--- a/Scripts/parameters/demand/ob_other.json
+++ b/Scripts/parameters/demand/ob_other.json
@@ -108,7 +108,6 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_time": -0.09693,
                 "within_zone_time": -0.09693
             },
             "impedance": {
@@ -126,7 +125,6 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.07648,
                 "within_zone_time": -0.07648
             },
             "impedance": {

--- a/Scripts/parameters/demand/wb_business.json
+++ b/Scripts/parameters/demand/wb_business.json
@@ -105,7 +105,6 @@
     "destination_choice": {
       "car_work": {
           "attraction": {
-              "park_time": -0.04707,
               "within_zone_time": -0.04707
           },
           "impedance": {
@@ -120,7 +119,6 @@
       },
       "car_pax": {
           "attraction": {
-              "park_time": -0.05097,
               "within_zone_time": -0.05097
           },
           "impedance": {

--- a/Scripts/parameters/demand/wb_other.json
+++ b/Scripts/parameters/demand/wb_other.json
@@ -105,7 +105,6 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "park_time": -0.12811,
                 "within_zone_time": -0.12811
             },
             "impedance": {
@@ -122,7 +121,6 @@
         },
         "car_pax": {
             "attraction": {
-                "park_time": -0.1365,
                 "within_zone_time": -0.1365
             },
             "impedance": {

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -53,7 +53,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_work"] + model.mode_share[0]["car_leisure"],
-            0.25467787853321716)
+            0.2395567297889474)
         
         print("Model system test done")
     


### PR DESCRIPTION
PR #21 had two flaws that are fixed here.

1) Park time parameter in json-files needs to be removed to avoid double counting.
2) Cost and time modification was applied only to matrices selected in `impedance_transform`.

These two had opposite effect on mode shares and therefore I didn't notice this earlier.