### PR TITLE
Change tour vectors into float32

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -80,8 +80,10 @@ class ZoneData:
         self.share["share_age_50-64"] = popdata["sh_50-64"]
         self.share["share_age_65-99"] = popdata["sh_65"]
         self.share["share_age_7-99"] = popdata["sh_7-17"] + popdata["sh_18-29"] + popdata["sh_30-49"] + popdata["sh_50-64"] + popdata["sh_65"]
-        self.share["share_female"] = pandas.Series(0.5, self.zone_numbers)
-        self.share["share_male"] = pandas.Series(0.5, self.zone_numbers)
+        self.share["share_female"] = pandas.Series(
+            0.5, self.zone_numbers, dtype=numpy.float32)
+        self.share["share_male"] = pandas.Series(
+            0.5, self.zone_numbers, dtype=numpy.float32)
         self["age_7-17_female"] = 0.5 * popdata["sh_7-17"] * pop
         self["age_18-29_female"] = 0.5 * popdata["sh_18-29"] * pop
         self["age_30-49_female"] = 0.5 * popdata["sh_30-49"] * pop

--- a/Scripts/models/car_use.py
+++ b/Scripts/models/car_use.py
@@ -63,7 +63,7 @@ class CarUseModel(LogitModel):
                 Choice probabilities
         """
         b = self.param
-        utility = numpy.zeros(self.bounds.stop)
+        utility = numpy.zeros(self.bounds.stop, dtype=numpy.float32)
         self._add_constant(utility, b["constant"])
         self._add_zone_util(utility, b["generation"], True)
         self.exps = numpy.exp(utility)

--- a/Scripts/models/generation.py
+++ b/Scripts/models/generation.py
@@ -1,3 +1,4 @@
+import numpy
 import pandas
 
 import parameters.tour_generation as param
@@ -26,7 +27,8 @@ class GenerationModel:
 
     def init_tours(self):
         """Initialize `tours` vector to 0."""
-        self.tours = pandas.Series(0, self.purpose.zone_numbers)
+        self.tours = pandas.Series(
+            0.0, self.purpose.zone_numbers, dtype=numpy.float32)
 
     def add_tours(self):
         """Generate and add (peripheral) tours to zone vector."""


### PR DESCRIPTION
When 32 bit probability matrix is multiplied by 64 bit tours vector, the result has become a 64 bit matrix. This matrix is handled only temporarily, so the effect on memory consumption is small, but for large networks this might be critical.