### PR TITLE
Do demand matrix aggregations for all available mappings

### DIFF
--- a/Scripts/datatypes/tour.py
+++ b/Scripts/datatypes/tour.py
@@ -159,9 +159,10 @@ class Tour:
         self.purpose.attracted_tours[self.mode][dest_idx] += 1
         self.purpose.histograms[self.mode].add(
             self.purpose.dist[orig_rel_idx, dest_idx])
-        area1 = self.purpose.mapping.iat[orig_idx]
-        area2 = self.purpose.mapping.iat[dest_idx]
-        self.purpose.aggregates[self.mode].at[area1, area2] += 1
+        for name in self.purpose.mappings:
+            i = self.purpose.mappings[name].iat[orig_idx]
+            j = self.purpose.mappings[name].iat[dest_idx]
+            self.purpose.aggregates[name][self.mode].at[i, j] += 1
         if orig_idx == dest_idx:
             self.purpose.own_zone_demand[self.mode].iat[orig_rel_idx] += 1
         bounds = self.purpose.sec_dest_purpose.bounds

--- a/Scripts/datatypes/zone.py
+++ b/Scripts/datatypes/zone.py
@@ -68,7 +68,7 @@ class ZoneAggregations:
             Matrix aggregated to the selected mapping
         """
         return self.aggregate_array(
-            self.aggregate_array(matrix, area_type).T, area_type)
+            self.aggregate_array(matrix, area_type).T, area_type).T
 
     def aggregate_array(self,
                         array: Union[pandas.Series, pandas.DataFrame],

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -424,21 +424,29 @@ class ModelSystem:
     def _export_model_results(self):
         gen_tours_purpose = {purpose.name: purpose.generated_tours_all
                              for purpose in self.dm.tour_purposes}
-        self.resultdata.print_data(gen_tours_purpose, "zone_generation_by_purpose.txt")
+        self.resultdata.print_data(
+            gen_tours_purpose, "zone_generation_by_purpose.txt")
         attr_tours_purpose = {purpose.name: purpose.attracted_tours_all
                               for purpose in self.dm.tour_purposes}
-        self.resultdata.print_data(attr_tours_purpose, "zone_attraction_by_purpose.txt")
+        self.resultdata.print_data(
+            attr_tours_purpose, "zone_attraction_by_purpose.txt")
         gen_tours_mode = {mode: self._generated_tours_mode(mode)
                            for mode in self.travel_modes}
-        self.resultdata.print_data(gen_tours_mode, "zone_generation_by_mode.txt")
+        self.resultdata.print_data(
+            gen_tours_mode, "zone_generation_by_mode.txt")
         attr_tours_mode = {mode: self._attracted_tours_mode(mode)
                            for mode in self.travel_modes}
-        self.resultdata.print_data(attr_tours_mode, "zone_attraction_by_mode.txt")
+        self.resultdata.print_data(
+            attr_tours_mode, "zone_attraction_by_mode.txt")
         for purpose in self.dm.tour_purposes:
-            self.resultdata.print_concat(purpose.generation_mode_shares, "purpose_mode_shares.txt")
-            self.resultdata.print_concat(purpose.tour_lengths, "tour_lengths.txt")
-            self.resultdata.print_matrices(
-                purpose.aggregates, "aggregated_demand", purpose.name)
+            self.resultdata.print_concat(
+                purpose.generation_mode_shares, "purpose_mode_shares.txt")
+            self.resultdata.print_concat(
+                purpose.tour_lengths, "tour_lengths.txt")
+            for mapping in purpose.aggregates:
+                self.resultdata.print_matrices(
+                    purpose.aggregates[mapping],
+                    f"aggregated_demand_{mapping}", purpose.name)
             for mode in purpose.within_zone_tours:
                 self.resultdata.print_data(
                     purpose.within_zone_tours[mode], "within_zone_tours.txt")

--- a/Scripts/parameters/zone.py
+++ b/Scripts/parameters/zone.py
@@ -31,7 +31,6 @@ purpose_areas: Dict[str, Union[Tuple[int,int],Tuple[int,int,int]]] = {
     "all": (0, 2000, 36000),
     "external": (36000, 40000),
 }
-purpose_matrix_aggregation_level = "area"
 tour_length_intervals = (0, 3, 5, 10, 20, 30, 40, 100,
                          200, 400, 600, 800, float("inf"))
 # Population in noise zones as share of total area population as


### PR DESCRIPTION
Instead of one hard-coded aggregation level, all aggregation levels found in the .agg file will be used for printing separate files.

Also fix matrix direction, which has been wrong for a while.