### PR TITLE
Update long distance estimation with 2016 impedance

### DIFF
--- a/Scripts/parameters/demand/hb_business_long.json
+++ b/Scripts/parameters/demand/hb_business_long.json
@@ -63,8 +63,8 @@
         "airplane": {
             "attraction": {},
             "impedance": {
-                "time": -0.00051,
-                "cost": -0.0135
+                "time": -0.00047,
+                "cost": -0.01878
             },
             "log": {
                 "attraction_size": 1
@@ -76,8 +76,8 @@
         "train": {
             "attraction": {},
             "impedance": {
-                "time": -0.00072,
-                "cost": -0.0135
+                "time": -0.00054,
+                "cost": -0.01878
             },
             "log": {
                 "attraction_size": 1
@@ -89,8 +89,8 @@
         "long_d_bus": {
             "attraction": {},
             "impedance": {
-                "time": -0.00256,
-                "cost": -0.0135
+                "time": -0.002,
+                "cost": -0.01878
             },
             "log": {
                 "attraction_size": 1
@@ -102,8 +102,8 @@
         "car_work": {
             "attraction": {},
             "impedance": {
-                "time": -0.00491,
-                "cost": -0.0135
+                "time": -0.0038,
+                "cost": -0.01878
             },
             "log": {
                 "attraction_size": 1
@@ -115,7 +115,7 @@
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.00507
+                "time": -0.00518
             },
             "log": {
                 "attraction_size": 1
@@ -132,51 +132,51 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.61849
+                "logsum": 0.87623
             },
             "individual_dummy": {}
         },
         "train": {
-            "constant": -1.19903,
+            "constant": -1.95788,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.61849
+                "logsum": 0.87623
             },
             "individual_dummy": {}
         },
         "long_d_bus": {
-            "constant": -1.63808,
+            "constant": -2.01242,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.61849
+                "logsum": 0.87623
             },
             "individual_dummy": {}
         },
         "car_work": {
-            "constant": -0.14918,
+            "constant": -0.96966,
             "generation": {
-                "car_density": 3.62549
+                "car_density": 2.2341
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.61849
+                "logsum": 0.87623
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -4.24495,
+            "constant": -3.96928,
             "generation": {
-                "car_density": 6.38694
+                "car_density": 4.20913
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.61849
+                "logsum": 0.87623
             },
             "individual_dummy": {}
         }

--- a/Scripts/parameters/demand/hb_leisure_long.json
+++ b/Scripts/parameters/demand/hb_leisure_long.json
@@ -62,86 +62,86 @@
     "destination_choice": {
         "airplane": {
             "attraction": {
-                "ski_resort": 0.67627
+                "ski_resort": 0.55414
             },
             "impedance": {
-                "time": -0.00058,
-                "cost": -0.01157
+                "time": -0.00042,
+                "cost": -0.01324
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "population": 1,
-                "hospitality": 228.558,
-                "area_leisure": 0.43746
+                "hospitality": 203.30148,
+                "area_leisure": 0.37395
             }
         },
         "train": {
             "attraction": {
-                "ski_resort": 0.67627
+                "ski_resort": 0.55414
             },
             "impedance": {
                 "time": -0.00038,
-                "cost": -0.01157
+                "cost": -0.01324
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "population": 1,
-                "hospitality": 228.558,
-                "area_leisure": 0.43746
+                "hospitality": 203.30148,
+                "area_leisure": 0.37395
             }
         },
         "long_d_bus": {
             "attraction": {
-                "ski_resort": 0.67627
+                "ski_resort": 0.55414
             },
             "impedance": {
-                "time": -0.00204,
-                "cost": -0.01157
+                "time": -0.00171,
+                "cost": -0.01324
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "population": 1,
-                "hospitality": 228.558,
-                "area_leisure": 0.43746
+                "hospitality": 203.30148,
+                "area_leisure": 0.37395
             }
         },
         "car_leisure": {
             "attraction": {
-                "ski_resort": 0.67627
+                "ski_resort": 0.55414
             },
             "impedance": {
-                "time": -0.0026,
-                "cost": -0.01157
+                "time": -0.00229,
+                "cost": -0.01324
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "population": 1,
-                "hospitality": 228.558,
-                "area_leisure": 0.43746
+                "hospitality": 203.30148,
+                "area_leisure": 0.37395
             }
         },
         "car_pax": {
             "attraction": {
-                "ski_resort": 0.67627
+                "ski_resort": 0.55414
             },
             "impedance": {
-                "time": -0.00468
+                "time": -0.00464
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "population": 1,
-                "hospitality": 228.558,
-                "area_leisure": 0.43746
+                "hospitality": 203.30148,
+                "area_leisure": 0.37395
             }
         }
     },
@@ -152,51 +152,51 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.66437
+                "logsum": 0.64157
             },
             "individual_dummy": {}
         },
         "train": {
-            "constant": -0.49779,
+            "constant": 0.10472,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.66437
+                "logsum": 0.64157
             },
             "individual_dummy": {}
         },
         "long_d_bus": {
-            "constant": 0.89891,
+            "constant": 1.43444,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.66437
+                "logsum": 0.64157
             },
             "individual_dummy": {}
         },
         "car_leisure": {
-            "constant": 1.11932,
+            "constant": 1.74496,
             "generation": {
-                "car_density": 3.58656
+                "car_density": 3.68681
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.66437
+                "logsum": 0.64157
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": 0.80303,
+            "constant": 1.41433,
             "generation": {
-                "car_density": 3.25339
+                "car_density": 3.35278
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.66437
+                "logsum": 0.64157
             },
             "individual_dummy": {}
         }

--- a/Scripts/parameters/demand/hb_work_long.json
+++ b/Scripts/parameters/demand/hb_work_long.json
@@ -63,8 +63,8 @@
         "airplane": {
             "attraction": {},
             "impedance": {
-                "time": -0.00101,
-                "cost": -0.02499
+                "time": -0.00072,
+                "cost": -0.02956
             },
             "log": {
                 "attraction_size": 1
@@ -76,8 +76,8 @@
         "train": {
             "attraction": {},
             "impedance": {
-                "time": -0.00082,
-                "cost": -0.02499
+                "time": -0.00079,
+                "cost": -0.02956
             },
             "log": {
                 "attraction_size": 1
@@ -89,8 +89,8 @@
         "long_d_bus": {
             "attraction": {},
             "impedance": {
-                "time": -0.00094,
-                "cost": -0.02499
+                "time": -0.00065,
+                "cost": -0.02956
             },
             "log": {
                 "attraction_size": 1
@@ -102,8 +102,8 @@
         "car_work": {
             "attraction": {},
             "impedance": {
-                "time": -0.0018,
-                "cost": -0.02499
+                "time": -0.00105,
+                "cost": -0.02956
             },
             "log": {
                 "attraction_size": 1
@@ -115,7 +115,7 @@
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.00379
+                "time": -0.00385
             },
             "log": {
                 "attraction_size": 1
@@ -132,49 +132,49 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.94668
+                "logsum": 1
             },
             "individual_dummy": {}
         },
         "train": {
-            "constant": -3.28818,
+            "constant": -2.71963,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.94668
+                "logsum": 1
             },
             "individual_dummy": {}
         },
         "long_d_bus": {
-            "constant": -4.61672,
+            "constant": -3.98842,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.94668
+                "logsum": 1
             },
             "individual_dummy": {}
         },
         "car_work": {
-            "constant": -4.12789,
+            "constant": -3.56968,
             "generation": {
-                "car_density": 3.61899
+                "car_density": 3.35914
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.94668
+                "logsum": 1
             },
             "individual_dummy": {}
         },
         "car_pax": {
-            "constant": -5.95346,
+            "constant": -5.35781,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.94668
+                "logsum": 1
             },
             "individual_dummy": {}
         }


### PR DESCRIPTION
New 2016 impedance matrices used for estimation. Previous attempts had errors in aiplane transit time function, which caused bias in impedance data and parameters. Also Lapland flight connections with zero travel time was updated in matrices.