### PR TITLE
Add log messages to monitor demand model progress

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -128,7 +128,7 @@ class Purpose:
                     m = row["mode"]
                     p = row["cost_change"]
                     day_imp[m][t] = p * day_imp[m][t]
-                    msg = (f"Demand calculation {self.name}: " 
+                    msg = (f"Purpose {self.name}: " 
                            + f"Added {round(100*(p-1))} % to {t} : {m}.")
                     log.warn(msg)
                 except KeyError:
@@ -149,6 +149,7 @@ class Purpose:
                                                     self.zone_data["park_cost"].values)
                     except KeyError:
                         pass
+        log.info(f"Matrix transformations completed for {self.name}")
         return day_imp
 
 
@@ -329,6 +330,7 @@ class TourPurpose(Purpose):
             self.within_zone_tours[mode] = pandas.Series(
                 numpy.diag(mtx), self.zone_numbers,
                 name="{}_{}".format(self.name, mode))
+        log.info(f"Demand calculated for {self.name}")
         return demand
 
 

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -173,6 +173,7 @@ class ModelSystem:
                 if purpose.dest != "source":
                     for mode in demand:
                         self.dtm.add_demand(demand[mode])
+                    log.info(f"Time period matrices calculated for {purpose.name}")
         log.info("Demand calculation completed")
 
     def _add_external_demand(self,


### PR DESCRIPTION
Demand model can run > hour without any progress reports, so add few purpose specific messages.