### PR TITLE
Add end_assignment_only parameter to lem_validate_inputfiles

### DIFF
--- a/Scripts/lem_validate_inputfiles.py
+++ b/Scripts/lem_validate_inputfiles.py
@@ -48,8 +48,7 @@ def main(args):
 
     # Check basedata input
     log.info("Checking base inputdata...")
-    # Check filepaths (& first .emp path for zone_numbers in base zonedata)
-    if not base_zonedata_path.exists():
+    if not (args.end_assignment_only or base_zonedata_path.exists()):
         msg = "Baseline zonedata file '{}' does not exist.".format(
             base_zonedata_path)
         log.error(msg)
@@ -215,6 +214,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--log-format",
         choices={"TEXT", "JSON"},
+    )
+    parser.add_argument(
+        "-o", "--end-assignment-only",
+        action="store_true",
+        help="Using this flag runs only end assignment of base demand matrices.",
     )
     parser.add_argument(
         "-f", "--long-dist-demand-forecast",

--- a/Scripts/tests/integration/test_helmet_validation.py
+++ b/Scripts/tests/integration/test_helmet_validation.py
@@ -9,6 +9,7 @@ from tests.integration.test_data_handling import (
 class Args:
     log_format = None
     log_level = "DEBUG"
+    end_assignment_only = False
     baseline_data_path = TEST_DATA_PATH / "Base_input_data"
     emme_paths = [ZONEDATA_PATH / "2016.cco"]
     first_scenario_ids = ["test"]


### PR DESCRIPTION
If only doing one end-assignment-only model run, we should not assume that there is base zone-data available.