### PR TITLE
Fix EMME dimensions

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -900,4 +900,7 @@ class AssignmentPeriod(Period):
         network = self.emme_scenario.get_network()
         for link in network.links():
             link[volax_attr] = link.aux_transit_volume
+        time_attr = self.extra(param.uncongested_transit_time)
+        for segment in network.transit_segments():
+            segment[time_attr] = segment.transit_time
         self.emme_scenario.publish_network(network)

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -363,6 +363,7 @@ class EmmeAssignmentModel(AssignmentModel):
         for ap in self.assignment_periods:
             network = ap.emme_scenario.get_network()
             volume_factor = param.volume_factors["bus"][ap.name]
+            time_attr = ap.extra(param.uncongested_transit_time)
             for line in network.transit_lines():
                 mode = line.vehicle.description
                 headway = line[ap.netfield("hdw")]
@@ -370,8 +371,7 @@ class EmmeAssignmentModel(AssignmentModel):
                     departures = volume_factor * 60/headway
                     for segment in line.segments():
                         miles["dist"][mode] += departures * segment.link.length
-                        miles["time"][mode] += (departures
-                                                * segment[ap.extra("base_timtr")])
+                        miles["time"][mode] += departures * segment[time_attr]
         resultdata.print_data(miles, "transit_kms.txt")
 
     def calc_transit_cost(self, fares: pandas.DataFrame):
@@ -646,12 +646,6 @@ class EmmeAssignmentModel(AssignmentModel):
         self.emme_project.create_extra_attribute(
             "TRANSIT_SEGMENT", param.extra_waiting_time["penalty"],
             "wait time st.dev.", overwrite=True, scenario=scenario)
-        self.emme_project.create_extra_attribute(
-            "TRANSIT_SEGMENT", "@" + param.congestion_cost,
-            "transit congestion cost", overwrite=True, scenario=scenario)
-        self.emme_project.create_extra_attribute(
-            "TRANSIT_SEGMENT", "@" + param.uncongested_transit_time,
-            "uncongested transit time", overwrite=True, scenario=scenario)
         self.emme_project.create_extra_attribute(
             "TRANSIT_SEGMENT", extra(param.uncongested_transit_time),
             "uncongested transit time", overwrite=True, scenario=scenario)

--- a/Scripts/assignment/emme_bindings/mock_project.py
+++ b/Scripts/assignment/emme_bindings/mock_project.py
@@ -967,6 +967,7 @@ class TransitSegment(NetworkObject):
         self.allow_boardings = False
         self.transit_time_func = 0
         self.dwell_time = 0.01
+        self.transit_time = 0.1
 
     @property
     def id(self) -> str:

--- a/Scripts/create_emme_project.py
+++ b/Scripts/create_emme_project.py
@@ -1,6 +1,5 @@
 from argparse import ArgumentParser
 from pathlib import Path
-import logging
 
 import utils.config
 import utils.log as log
@@ -10,63 +9,39 @@ import inro.emme.database.emmebank as _eb
 import parameters.assignment as param
 
 def create_emme_project(args):
-    logging.basicConfig(format='%(asctime)s %(message)s',
-                            datefmt='%Y-%m-%d %H:%M:%S',
-                            level=logging.INFO)
     project_dir = args.emme_path
     project_name = args.project_name
     db_dir = Path(project_dir, project_name, "Database")
     project_path = _app.create_project(project_dir, project_name)
     db_dir.mkdir(parents=True, exist_ok=True)
     default_dimensions = {
-        "scalar_matrices": 100, 
-        "origin_matrices": 100, 
-        "destination_matrices": 100, 
-        "full_matrices": 600, 
-        "scenarios": args.number_of_emme_scenarios, 
-        "turn_entries": 1, 
-        "transit_vehicles": 40, 
-        "functions": 99, 
-        "operators": 5000, 
+        "scalar_matrices": 100,
+        "origin_matrices": 100,
+        "destination_matrices": 100,
+        "full_matrices": 9999,
+        "scenarios": args.number_of_emme_scenarios,
+        "turn_entries": 100,
+        "transit_vehicles": 40,
+        "functions": 99,
+        "operators": 5000,
         "sola_analyses": 240,
     }
     submodel_dimensions = {
-        "uusimaa": {
-            "centroids": 3000, 
-            "regular_nodes": 40000, 
-            "links": 150000,
-            "transit_lines": 3000,
-            "transit_segments": 250000,
-        },
-        "lounais_suomi": {
-            "centroids": 3000, 
-            "regular_nodes": 45000, 
-            "links": 150000,
-            "transit_lines": 3000,
-            "transit_segments": 250000,            
-        },
-        "ita_suomi": {
-            "centroids": 3300, 
-            "regular_nodes": 45000, 
+        "alueelliset_osamallit": {
+            "centroids": 3300,
+            "regular_nodes": 45000,
             "links": 150000,
             "transit_lines": 3300,
-            "transit_segments": 300000,           
-        },
-        "pohjois_suomi": {
-            "centroids": 3000, 
-            "regular_nodes": 40000, 
-            "links": 150000,
-            "transit_lines": 2500,
-            "transit_segments": 200000,                 
+            "transit_segments": 300000,
         },
         "koko_suomi": {
-            "centroids": 10000, 
-            "regular_nodes": 120000, 
+            "centroids": 10000,
+            "regular_nodes": 120000,
             "links": 350000,
             "transit_lines": 8000,
-            "transit_segments": 700000,                
+            "transit_segments": 700000,
         },
-        "freight": {
+        "koko_suomi_kunta": {
             "centroids": 320,
             "regular_nodes": 50000,
             "links": 130000,
@@ -74,12 +49,12 @@ def create_emme_project(args):
             "transit_segments": 500000,
         }
     }
-
     nr_transit_classes = len(param.transit_classes)
     nr_segment_results = len(param.segment_results)
     nr_veh_classes = len(param.emme_matrices)
-    nr_new_attr = {
-        "nodes": nr_transit_classes * (nr_segment_results-1),
+    nr_attr = {
+        "centroids": nr_transit_classes * (nr_segment_results-1),
+        "regular_nodes": nr_transit_classes * (nr_segment_results-1),
         "links": nr_veh_classes + len(param.park_and_ride_classes) + 1,
         "transit_lines": nr_transit_classes + 2,
         "transit_segments": nr_transit_classes*nr_segment_results + 2,
@@ -88,17 +63,14 @@ def create_emme_project(args):
     if not args.separate_emme_scenarios:
     # If results from all time periods are stored in same
     # EMME scenario
-        for key in nr_new_attr:
-            nr_new_attr[key] *= len(param.time_periods) + 1
+        for key in nr_attr:
+            nr_attr[key] *= len(param.time_periods) + 1
 
     # calculate extra attribute dimensions:
-    for i in submodel_dimensions:
-        submodel_dimensions[i]["extra_attribute_values"] = (submodel_dimensions[i]["links"] * 9 * nr_new_attr["links"]
-                                                            + (submodel_dimensions[i]["regular_nodes"] + submodel_dimensions[i]["centroids"]) * 5 * nr_new_attr["nodes"]
-                                                            + submodel_dimensions[i]["transit_lines"] * nr_new_attr["transit_lines"]
-                                                            + submodel_dimensions[i]["transit_segments"] * nr_new_attr["transit_segments"])
+    dim = submodel_dimensions[args.submodel]
+    dim["extra_attribute_values"] = sum(dim[key]*nr_attr[key] for key in dim)
 
-    dim = {**default_dimensions, **submodel_dimensions[args.submodel]}
+    dim.update(default_dimensions)
     scenario_num = args.first_scenario_id
     eb = _eb.create(db_dir / "emmebank", dim)
     eb.text_encoding = 'utf-8'

--- a/Scripts/lem_validate_inputfiles.py
+++ b/Scripts/lem_validate_inputfiles.py
@@ -143,8 +143,6 @@ def main(args):
                 # EMME scenario
                 for key in nr_new_attr:
                     nr_new_attr[key] *= len(time_periods) + 1
-            # Attributes created during congested transit assignment
-            nr_new_attr["transit_segments"] += 3
             dim = emmebank.dimensions
             dim["nodes"] = dim["centroids"] + dim["regular_nodes"]
             attr_space = 0

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -540,8 +540,6 @@ segment_results = {
     "total_boardings": "boa",
     "transfer_boardings": "trb",
 }
-# Hard-coded in Emme congested transit assignment
-congestion_cost = "ccost"
 uncongested_transit_time = "base_timtr"
 emme_matrices = {
     "car_work": ("demand", "time", "dist", "cost", "gen_cost"),


### PR DESCRIPTION
- Simplified dimensions in `create_emme_project.py` to have one set of dimensions shared by all regional sub-models
- Simplified and fixed extra attribute space calculation
- Removed attributes needed during congested transit assignment
- Fixed saving of transit time to extra attribute that had been missing since dropping congested assignment