### PR TITLE
Check if tour purposes are in tour combination model

### DIFF
--- a/Scripts/datatypes/histogram.py
+++ b/Scripts/datatypes/histogram.py
@@ -9,11 +9,15 @@ class TourLengthHistogram:
 
     def __init__(self, name):
         index = [f"{i}-{j}" for i, j in zip(intervals[:-1], intervals[1:])]
+        index.append("total_kms")
         self.histogram = pandas.concat(
             {name: pandas.Series(0.0, index, name="nr_of_tours")})
 
     def add(self, dist):
         self.histogram.iat[numpy.searchsorted(self._u, dist, "right")] += 1
+        self.histogram.iat[-1] += dist
 
     def count_tour_dists(self, tours, dists):
-        self.histogram[:], _ = numpy.histogram(dists, intervals, weights=tours)
+        self.histogram.iloc[:-1], _ = numpy.histogram(
+            dists, intervals, weights=tours)
+        self.histogram.iat[-1] = (dists * tours).sum()

--- a/Scripts/datatypes/histogram.py
+++ b/Scripts/datatypes/histogram.py
@@ -9,15 +9,11 @@ class TourLengthHistogram:
 
     def __init__(self, name):
         index = [f"{i}-{j}" for i, j in zip(intervals[:-1], intervals[1:])]
-        index.append("total_kms")
         self.histogram = pandas.concat(
             {name: pandas.Series(0.0, index, name="nr_of_tours")})
 
     def add(self, dist):
         self.histogram.iat[numpy.searchsorted(self._u, dist, "right")] += 1
-        self.histogram.iat[-1] += dist
 
     def count_tour_dists(self, tours, dists):
-        self.histogram.iloc[:-1], _ = numpy.histogram(
-            dists, intervals, weights=tours)
-        self.histogram.iat[-1] = (dists * tours).sum()
+        self.histogram[:], _ = numpy.histogram(dists, intervals, weights=tours)

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -144,10 +144,20 @@ class DemandModel:
         Not used in agent-based simulation.
         Result is stored in `purpose.gen_model.tours`.
         """
+        gm = self.tour_generation_model
+        combination_purposes = {purpose for combination in gm.tour_combinations
+            for purpose in combination}
+        use_tour_combination_model = False
         for purpose in self.tour_purposes:
             purpose.gen_model.init_tours()
             if not isinstance(purpose, SecDestPurpose):
                 purpose.gen_model.add_tours()
+            if purpose.name in combination_purposes:
+                use_tour_combination_model = True
+        if use_tour_combination_model:
+            self._generate_tour_combinations()
+
+    def _generate_tour_combinations(self):
         gm = self.tour_generation_model
         for age in self._age_strings():
             segments = self.segments[age]


### PR DESCRIPTION
This will prevent long-distance tour model from running the tour combination model, which requires logsums from short-tour model.