### PR TITLE
Fix `DestModeModel`

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -243,6 +243,7 @@ class TourPurpose(Purpose):
             self.model = logit.OriginModel(*args)
         elif specification["struct"] == "dest>mode":
             self.model = logit.DestModeModel(*args)
+            self.accessibility_model = self.model
         else:
             self.model = logit.ModeDestModel(*args)
             self.accessibility_model = logit.AccessibilityModel(*args)
@@ -304,7 +305,7 @@ class TourPurpose(Purpose):
                 Type (time/cost/dist) : numpy 2d matrix
         """
         purpose_impedance = self.transform_impedance(impedance)
-        if is_last_iteration and self.name[0] != 's':
+        if is_last_iteration:
             self.accessibility_model.calc_accessibility(
                 copy(purpose_impedance))
         self.prob = self.model.calc_prob(purpose_impedance)

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -11,6 +11,13 @@ if TYPE_CHECKING:
 import parameters.zone as param
 
 
+def log(a: numpy.array):
+    with numpy.errstate(divide="ignore"):
+        return numpy.log(a)
+
+def divide(a, b):
+    return numpy.divide(a, b, out=numpy.zeros_like(a), where=b!=0)
+
 class LogitModel:
     """Generic logit model with mode/destination choice.
 
@@ -164,13 +171,13 @@ class LogitModel:
         for i in b:
             try: # If only one parameter
                 imp = impedance[i] + 1 if b[i] < 0 else impedance[i]
-                utility += b[i] * numpy.log(imp)
+                utility += b[i] * log(imp)
             except ValueError: # Separate sub-region parameters
                 for j, bounds in enumerate(self.sub_bounds):
                     imp = impedance[i][bounds, :]
                     if b[i][j] < 0:
                         imp += 1
-                    utility[bounds, :] += b[i][j] * numpy.log(imp)
+                    utility[bounds, :] += b[i][j] * log(imp)
         return utility
 
     def _add_zone_util(self, utility, b, generation=False):
@@ -414,11 +421,11 @@ class ModeDestModel(LogitModel):
             dest_expsums[mode] = {"logsum": expsum}
             label = self.purpose.name + "_" + mode
             logsum = pandas.Series(
-                numpy.log(expsum), self.purpose.zone_numbers, name=label)
+                log(expsum), self.purpose.zone_numbers, name=label)
             self.zone_data._values[label] = logsum
         mode_expsum = self._calc_mode_util(dest_expsums)
         logsum = pandas.Series(
-            numpy.log(mode_expsum), self.purpose.zone_numbers,
+            log(mode_expsum), self.purpose.zone_numbers,
             name=self.purpose.name)
         self.zone_data._values[self.purpose.name] = logsum
         return mode_expsum, dest_exps, dest_expsums
@@ -429,14 +436,10 @@ class ModeDestModel(LogitModel):
         prob = {}
         for mode in self.mode_choice_param:
             mode_exps = self.mode_exps[mode]
-            mode_prob = numpy.divide(
-                mode_exps, mode_expsum, out=numpy.zeros_like(mode_exps),
-                where=mode_expsum!=0)
+            mode_prob = divide(mode_exps, mode_expsum)
             dest_exp = dest_exps.pop(mode).T
             dest_expsum = dest_expsums[mode]["logsum"]
-            dest_prob = numpy.divide(
-                dest_exp, dest_expsum, out=numpy.zeros_like(dest_exp),
-                where=dest_expsum!=0)
+            dest_prob = divide(dest_exp, dest_expsum)
             prob[mode] = mode_prob * dest_prob
         return prob
 
@@ -531,9 +534,9 @@ class AccessibilityModel(ModeDestModel):
         """
         for i in b:
             try: # If only one parameter
-                utility += b[i] * numpy.log(impedance[i] + 1)
+                utility += b[i] * log(impedance[i] + 1)
             except ValueError: # Separate params for cap region and surrounding
-                utility += b[i][0] * numpy.log(impedance[i] + 1)
+                utility += b[i][0] * log(impedance[i] + 1)
         return utility
 
     def _add_zone_util(self, utility, b, generation=False):
@@ -613,14 +616,14 @@ class DestModeModel(LogitModel):
         except ValueError:
             dest_expsum = dest_exps.sum()
         logsum = pandas.Series(
-            numpy.log(dest_expsum), self.purpose.zone_numbers,
+            log(dest_expsum), self.purpose.zone_numbers,
             name=self.purpose.name)
         self.accessibility = {"all": logsum}
         self.zone_data._values[self.purpose.name] = logsum
         prob = {}
-        dest_prob = dest_exps.T / dest_expsum
-        for mode in self.mode_choice_param:
-            mode_prob = (self.mode_exps[mode] / mode_expsum).T
+        dest_prob = divide(dest_exps.T, dest_expsum)
+        for mode, mode_exps in self.mode_exps.items():
+            mode_prob = divide(mode_exps, mode_expsum).T
             prob[mode] = mode_prob * dest_prob
         return prob
 


### PR DESCRIPTION
- Fixed deprecated `_calc_dest_util` method call in `DestModeModel`
- Fixed logit test to work also with `DestModeModel`
- Added `DestModeModel` logsum that can be used by tour generation model
- Added placeholder for accessibility measures and printing

Please note that there are no mode-specific logsums in the `DestModeModel` (as mode choice is on the OD level), so they cannot be used as a zone variable without some kind of not-yet-existing magic.