### PR TITLE
Move `avg` function to `zone` module and use it there for aggregation

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -9,7 +9,7 @@ import json
 
 import parameters.zone as param
 import utils.log as log
-from datatypes.zone import Zone, ZoneAggregations
+from datatypes.zone import Zone, ZoneAggregations, avg
 
 
 class ZoneData:
@@ -276,9 +276,3 @@ def read_zonedata(path: Path,
         log.error(msg)
         raise IndexError(msg)
     return data, zone_mapping
-
-def avg(data, weights):
-    try:
-        return numpy.average(data, weights=weights[data.index])
-    except ZeroDivisionError:
-        return 0

--- a/Scripts/datatypes/zone.py
+++ b/Scripts/datatypes/zone.py
@@ -44,8 +44,7 @@ class ZoneAggregations:
         pandas.Series
             Aggregated array
         """
-        avg = lambda a, w: numpy.ma.average(a, weights=w[a.index])
-        agg = array.groupby(self.mappings[area_type]).agg(avg, w=weights)
+        agg = array.groupby(self.mappings[area_type]).agg(avg, weights=weights)
         agg["all"] = avg(array, weights)
         return agg
 
@@ -98,3 +97,10 @@ class Zone:
         Zone.counter += 1
         self.county = aggregations.mappings["county"][number]
         self.municipality = aggregations.mappings["municipality"][number]
+
+
+def avg(data, weights):
+    try:
+        return numpy.average(data, weights=weights[data.index])
+    except ZeroDivisionError:
+        return 0


### PR DESCRIPTION
This removes the "invalid value encountered in scalar divide" warning.