### PR TITLE
Create new `WholeDayPeriod` for long-dist assignment

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -67,6 +67,7 @@ class AssignmentPeriod(Period):
                                   + param.local_transit_classes)
         self._end_assignment_classes = set(self.transport_classes
             if delete_extra_matrices else param.transport_classes)
+        self._end_assignment_classes.add("walk")
         self.assignment_modes: Dict[str, AssignmentMode] = {}
 
     def extra(self, attr: str) -> str:

--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -67,7 +67,6 @@ class AssignmentPeriod(Period):
                                   + param.local_transit_classes)
         self._end_assignment_classes = set(self.transport_classes
             if delete_extra_matrices else param.transport_classes)
-        self._end_assignment_classes.add("walk")
         self.assignment_modes: Dict[str, AssignmentMode] = {}
 
     def extra(self, attr: str) -> str:
@@ -121,6 +120,7 @@ class AssignmentPeriod(Period):
         """
         self._prepare_cars(dist_unit_cost, save_matrices)
         self._prepare_walk_and_bike(save_matrices=True)
+        self._end_assignment_classes.add("walk")
         self._prepare_transit(day_scenario, save_matrices, save_matrices)
 
     def _prepare_cars(self, dist_unit_cost: Dict[str, float],

--- a/Scripts/assignment/datatypes/car_specification.py
+++ b/Scripts/assignment/datatypes/car_specification.py
@@ -30,7 +30,7 @@ class CarSpecification:
 
     def light_spec(self) -> Dict[str, Any]:
         specs = []
-        for mode in param.car_classes + ("van",):
+        for mode in param.car_and_van_classes:
             self._modes[mode].init_matrices()
             specs.append(self._modes[mode].spec)
         self._spec["classes"] = specs

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -110,7 +110,6 @@ class EmmeAssignmentModel(AssignmentModel):
             self.assignment_periods.append(vars(periods)[self.time_periods[tp]](
                 tp, scen_id, self.emme_project,
                 separate_emme_scenarios=self.separate_emme_scenarios,
-                use_free_flow_speeds=self.use_free_flow_speeds,
                 use_stored_speeds=self.use_stored_speeds,
                 delete_extra_matrices=self.delete_extra_matrices))
         ass_classes = param.transport_classes + ("bus",)
@@ -143,8 +142,7 @@ class EmmeAssignmentModel(AssignmentModel):
             Class names for which we want extra attributes
         """
         self.freight_network = FreightAssignmentPeriod(
-            "vrk", self.mod_scenario.number, self.emme_project,
-            use_free_flow_speeds=True)
+            "vrk", self.mod_scenario.number, self.emme_project)
         self.assignment_periods = [self.freight_network]
         self.emme_project.create_extra_attribute(
             "TRANSIT_LINE", param.terminal_cost_attr, "terminal cost",

--- a/Scripts/assignment/freight_assignment.py
+++ b/Scripts/assignment/freight_assignment.py
@@ -8,6 +8,11 @@ from assignment.datatypes.freight_specification import FreightMode
 
 
 class FreightAssignmentPeriod(AssignmentPeriod):
+    def __init__(self, *args, **kwargs):
+        AssignmentPeriod.__init__(self, *args, **kwargs)
+        for criteria in self.stopping_criteria.values():
+                criteria["max_iterations"] = 0
+
     def prepare(self, dist_unit_cost: Dict[str, float], save_matrices: bool):
         self._prepare_cars(dist_unit_cost, save_matrices)
         network = self.emme_scenario.get_network()

--- a/Scripts/assignment/long_dist_period.py
+++ b/Scripts/assignment/long_dist_period.py
@@ -13,7 +13,8 @@ class WholeDayPeriod(AssignmentPeriod):
     """
     EMME assignment definition for long-distance trips.
 
-    This period represents the whole day.
+    This period represents the whole day and only long-distance modes.
+    Cars are assigned with free-flow speed.
     """
     def __init__(self, *args, **kwargs):
         AssignmentPeriod.__init__(self, *args, **kwargs)
@@ -48,10 +49,10 @@ class WholeDayPeriod(AssignmentPeriod):
             transit_classes=param.long_distance_transit_classes)
 
     def init_assign(self):
-         pass
+         self._set_car_vdfs(use_free_flow_speeds=True)
 
     def assign_trucks_init(self):
-         self._set_car_vdfs(use_free_flow_speeds=True)
+         pass
 
     def assign(self, modes: Iterable[str]
             ) -> Dict[str, Dict[str, numpy.ndarray]]:

--- a/Scripts/assignment/long_dist_period.py
+++ b/Scripts/assignment/long_dist_period.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING, Dict, Iterable
+import numpy
+
+from assignment.assignment_period import AssignmentPeriod
+import parameters.assignment as param
+from assignment.datatypes.car import CarMode
+from assignment.datatypes.car_specification import CarSpecification
+if TYPE_CHECKING:
+    from assignment.emme_bindings.emme_project import EmmeProject
+
+class WholeDayPeriod(AssignmentPeriod):
+    """
+    EMME assignment definition for long-distance trips.
+
+    This period represents the whole day.
+    """
+    def __init__(self, *args, **kwargs):
+        AssignmentPeriod.__init__(self, *args, **kwargs)
+        for criteria in self.stopping_criteria.values():
+                criteria["max_iterations"] = 0
+        self.transport_classes = (param.car_classes
+                                  + param.long_distance_transit_classes)
+
+    def prepare(self, dist_unit_cost: Dict[str, float],
+                day_scenario: int, save_matrices: bool):
+        """Prepare network for assignment.
+
+        Calculate road toll cost and specify car assignment.
+        Set boarding penalties and attribute names.
+
+        Parameters
+        ----------
+        dist_unit_cost : dict
+            key : str
+                Assignment class (car_work/truck/...)
+            value : float
+                Length multiplier to calculate link cost
+        day_scenario : int
+            EMME scenario linked to the whole day
+        save_matrices : bool
+            Whether matrices will be saved in Emme format for all time periods
+        """
+        self._prepare_cars(dist_unit_cost, save_matrices, truck_classes=[])
+        self._prepare_transit(
+            day_scenario, save_standard_matrices=True,
+            save_extra_matrices=save_matrices,
+            transit_classes=param.long_distance_transit_classes)
+
+    def init_assign(self):
+         pass
+
+    def assign_trucks_init(self):
+         self._set_car_vdfs(use_free_flow_speeds=True)
+
+    def assign(self, modes: Iterable[str]
+            ) -> Dict[str, Dict[str, numpy.ndarray]]:
+        """Assign cars and long-distance transit for whole day.
+
+        Get travel impedance matrices.
+
+        Parameters
+        ----------
+        modes : Set of str
+            The assignment classes for which impedance matrices will be returned
+
+        Returns
+        -------
+        dict
+            Type (time/cost/dist) : dict
+                Assignment class (car_work/transit/...) : numpy 2-d matrix
+        """
+        self._assign_cars(self.stopping_criteria["coarse"])
+        self._assign_transit(param.long_distance_transit_classes)
+        self._long_distance_trips_assigned = True
+        mtxs = self._get_impedances(modes)
+        for ass_cl in param.car_classes:
+            del mtxs["dist"][ass_cl]
+        del mtxs["toll_cost"]
+        return mtxs
+
+    def end_assign(self) -> Dict[str, Dict[str, numpy.ndarray]]:
+        """Assign cars and long-distance transit for whole day.
+
+        Get travel impedance matrices.
+
+        Returns
+        -------
+        dict
+            Type (time/cost/dist) : dict
+                Assignment class (car_work/transit/...) : numpy 2-d matrix
+        """
+        self._assign_cars(self.stopping_criteria["fine"])
+        if not self._long_distance_trips_assigned:
+            self._assign_transit(param.long_distance_transit_classes)
+        self._calc_transit_network_results(
+            param.long_distance_transit_classes)
+        return self._get_impedances(self.transport_classes)

--- a/Scripts/assignment/mock_assignment.py
+++ b/Scripts/assignment/mock_assignment.py
@@ -81,6 +81,7 @@ class MockPeriod(Period):
         self.transport_classes = (param.private_classes
                                   + param.local_transit_classes)
         self._end_assignment_classes = set(end_assignment_classes)
+        self._end_assignment_classes.add("walk")
 
     @property
     def zone_numbers(self):
@@ -228,6 +229,10 @@ class OffPeakPeriod(MockPeriod):
         for ass_cl in param.car_classes:
             mtxs["cost"][ass_cl] += (self.dist_unit_cost[ass_cl]
                                         * mtxs["dist"][ass_cl])
+        if "toll_cost" in mtxs:
+            for ass_cl in mtxs["toll_cost"]:
+                mtxs["cost"][ass_cl] += mtxs["toll_cost"][ass_cl]
+            del mtxs["toll_cost"]
         del mtxs["dist"]
         return mtxs
 
@@ -244,6 +249,8 @@ class TransitAssignmentPeriod(MockPeriod):
         """
         mtxs = self._get_impedances(param.local_transit_classes)
         del mtxs["dist"]
+        if "toll_cost" in mtxs:
+            del mtxs["toll_cost"]
         return mtxs
 
     def end_assign(self) -> Dict[str, Dict[str, numpy.ndarray]]:

--- a/Scripts/assignment/mock_assignment.py
+++ b/Scripts/assignment/mock_assignment.py
@@ -21,21 +21,15 @@ class MockAssignmentModel(AssignmentModel):
         self.matrices = matrices
         log.info("Reading matrices from " + str(self.matrices.path))
         self.use_free_flow_speeds = use_free_flow_speeds
-        end_assignment_classes = set(param.transport_classes)
-        if delete_extra_matrices:
-            end_assignment_classes -= set(param.freight_classes)
-            if use_free_flow_speeds:
-                end_assignment_classes -= set(param.local_transit_classes)
-            else:
-                end_assignment_classes -= set(
-                    param.long_distance_transit_classes)
+        end_ass_classes = ((param.private_classes + param.local_transit_classes)
+            if delete_extra_matrices else param.transport_classes)
         self.time_periods = {}
         cls = globals()
         for tp, class_name in time_periods.items():
             self.time_periods[tp] = (cls[class_name] if class_name in cls
                                      else MockPeriod)
         self.assignment_periods = [self.time_periods[tp](
-                tp, matrices, end_assignment_classes)
+                tp, matrices, end_ass_classes)
             for tp in time_periods]
 
     @property
@@ -84,7 +78,9 @@ class MockPeriod(Period):
                  end_assignment_classes: Iterable[str]):
         self.name = name
         self.matrices = matrices
-        self._end_assignment_classes = end_assignment_classes
+        self.transport_classes = (param.private_classes
+                                  + param.local_transit_classes)
+        self._end_assignment_classes = set(end_assignment_classes)
 
     @property
     def zone_numbers(self):
@@ -203,6 +199,20 @@ class MockPeriod(Period):
             mtx[ass_class] = matrix
 
 
+class WholeDayPeriod(MockPeriod):
+    def end_assign(self) -> Dict[str, Dict[str, numpy.ndarray]]:
+        """ Get travel impedance matrices for whole day from files.
+
+        Returns
+        -------
+        dict
+            Type (time/cost/dist) : dict
+                Assignment class (car_work/transit_leisure/...) : numpy 2-d matrix
+        """
+        return self._get_impedances(
+            param.car_classes + param.long_distance_transit_classes)
+
+
 class OffPeakPeriod(MockPeriod):
     def assign(self, *args) -> Dict[str, Dict[str, numpy.ndarray]]:
         """Get travel impedance matrices for one time period from files.
@@ -249,7 +259,7 @@ class TransitAssignmentPeriod(MockPeriod):
                 Assignment class (transit_work/...) : numpy 2-d matrix
         """
         self._end_assignment_classes -= set(
-            param.private_classes + param.freight_classes)
+            param.private_classes + param.truck_classes)
         return self._get_impedances(self._end_assignment_classes)
 
 class EndAssignmentOnlyPeriod(MockPeriod):

--- a/Scripts/assignment/mock_assignment.py
+++ b/Scripts/assignment/mock_assignment.py
@@ -81,7 +81,6 @@ class MockPeriod(Period):
         self.transport_classes = (param.private_classes
                                   + param.local_transit_classes)
         self._end_assignment_classes = set(end_assignment_classes)
-        self._end_assignment_classes.add("walk")
 
     @property
     def zone_numbers(self):
@@ -111,6 +110,7 @@ class MockPeriod(Period):
             Type (time/cost/dist) : dict
                 Assignment class (car_work/transit_leisure/...) : numpy 2-d matrix
         """
+        self._end_assignment_classes.add("walk")
         mtxs = self._get_impedances(modes)
         for ass_cl in param.car_classes:
             mtxs["cost"][ass_cl] = (self.dist_unit_cost[ass_cl]

--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -1,5 +1,5 @@
 from typing import Dict, Iterable
-from numpy.core import ndarray
+from numpy import ndarray
 import copy
 
 from assignment.assignment_period import AssignmentPeriod

--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -3,6 +3,7 @@ from numpy.core import ndarray
 import copy
 
 from assignment.assignment_period import AssignmentPeriod
+from assignment.long_dist_period import WholeDayPeriod
 import parameters.assignment as param
 
 
@@ -134,7 +135,7 @@ class TransitAssignmentPeriod(OffPeakPeriod):
         """
         self._calc_transit_network_results()
         self._end_assignment_classes -= set(
-            param.private_classes + param.freight_classes)
+            param.private_classes + param.truck_classes)
         return self._get_impedances(self._end_assignment_classes)
 
 

--- a/Scripts/lem.py
+++ b/Scripts/lem.py
@@ -69,7 +69,7 @@ def main(args):
         "delete_extra_matrices": args.delete_extra_matrices,
     }
     if calculate_long_dist_demand:
-        kwargs["time_periods"] = {"vrk": "AssignmentPeriod"}
+        kwargs["time_periods"] = {"vrk": "WholeDayPeriod"}
     if args.do_not_use_emme:
         log.info("Initializing MockAssignmentModel...")
         mock_result_path = results_path / "Matrices" / args.submodel

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -266,20 +266,12 @@ class ModelSystem:
             tp = ap.name
             log.info("Assigning period {}...".format(tp))
             if is_end_assignment or not self.ass_model.use_free_flow_speeds:
-                if not self.ass_model.use_free_flow_speeds:
-                    transport_classes = (param.private_classes
-                                        + param.local_transit_classes
-                                        + ("van",))
-                else:
-                    transport_classes = (param.car_classes
-                                         + param.long_distance_transit_classes)
                 with self.basematrices.open(
                         "demand", tp, self.ass_model.zone_numbers,
-                        transport_classes=transport_classes) as mtx:
-                    for ass_class in transport_classes:
+                        transport_classes=ap.transport_classes) as mtx:
+                    for ass_class in ap.transport_classes:
                         self.dtm.demand[tp][ass_class] = mtx[ass_class]
-            if not self.ass_model.use_free_flow_speeds:
-                ap.init_assign()
+            ap.init_assign()
             ap.assign_trucks_init()
             impedance[tp] = (ap.end_assign() if is_end_assignment
                              else ap.assign(self.travel_modes))

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -442,7 +442,8 @@ car_classes = (
     "car_work",
     "car_leisure",
 )
-private_classes = car_classes + ("bike",)
+car_and_van_classes = car_classes + ("van",)
+private_classes = car_and_van_classes + ("bike",)
 park_and_ride_classes = (
     # "car_first_mile",
     # "car_last_mile",
@@ -462,8 +463,7 @@ truck_classes = (
     "semi_trailer",
     "trailer_truck",
 )
-freight_classes = truck_classes + ("van",)
-transport_classes = private_classes + transit_classes + freight_classes
+transport_classes = private_classes + transit_classes + truck_classes
 assignment_classes = {
     "hb_work": "work",
     "hb_edu_basic": "work",


### PR DESCRIPTION
Add separate EMME assignment definition for long-distance trips. This period represents the whole day and only long-distance modes. Cars are assigned with free-flow speed. `AssignmentPeriod` init parameter `use_free_flow_speeds` is dropped, because it is now set explicitly in `WholeDayPeriod` and `FreightPeriod`. Also added object variable `transport_classes`, which represents the main assignment classes of the model run.