### PR TITLE
Do zone-data variable multiplication on the fly

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -76,13 +76,12 @@ class ZoneData:
             if col.startswith("sh_wrk_"):
                 self[col.replace("sh_wrk_", "")] = data[col] * wp
         self.share["share_age_7-99"] = share_7_99
-        # Create diagonal matrix with zone area
+        # Create diagonal matrix
         self["within_zone"] = numpy.full((self.nr_zones, self.nr_zones), 0.0)
         self["within_zone"][numpy.diag_indices(self.nr_zones)] = 1.0
         # Two-way intrazonal distances from building distances
-        self["within_zone_dist"] = (self["within_zone"] 
-                                    * data["avg_building_distance"].values * 2)
-        self["within_zone_time"] = self["within_zone_dist"] / (20/60) # 20 km/h
+        self["dist"] = data["avg_building_distance"] * 2
+        self["time"] = self["dist"] / (20/60) # 20 km/h
         # Unavailability of intrazonal tours
         self["within_zone_inf"] = numpy.full((self.nr_zones, self.nr_zones), 0.0)
         self["within_zone_inf"][numpy.diag_indices(self.nr_zones)] = numpy.inf
@@ -176,13 +175,11 @@ class ZoneData:
         try:
             val = self._values[key]
         except KeyError as err:
-            keyl: List[str] = key.split('<')
-            if (len(keyl) == 2 and keyl[1] in (
-                    "within_municipality", "outside_municipality")):
-                # If parameter is only for own municipality or for all
-                # municipalities except own, array is multiplied by
-                # bool matrix
-                return (self[keyl[1]] * self._values[keyl[0]].values)[bounds, :]
+            keyl: List[str] = key.split('*')
+            if (len(keyl) == 2):
+                # If parameter is two-fold, they will be multiplied
+                return (self.get_data(keyl[0], bounds, generation)
+                        * self.get_data(keyl[1], bounds, generation))
             else:
                 raise KeyError(err)
         if val.ndim == 1: # If not a compound (i.e., matrix)

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -80,9 +80,8 @@ class ModelSystem:
             in cost_data["transit_cost"].values()}
         self.zdata_forecast = ZoneData(
             zone_data_path, self.zone_numbers, submodel)
-        within_zone_cost = (self.zdata_forecast["within_zone_dist"]
-                            * self.car_dist_cost["car_work"])
-        self.zdata_forecast["within_zone_cost"] = within_zone_cost
+        self.zdata_forecast["cost"] = (self.zdata_forecast["dist"]
+                                       * self.car_dist_cost["car_work"])
 
         # Output data
         self.resultdata = ResultsData(results_path)

--- a/Scripts/parameters/demand/hb_edu_basic.json
+++ b/Scripts/parameters/demand/hb_edu_basic.json
@@ -71,7 +71,7 @@
     "destination_choice": {
         "car_pax": {
             "attraction": {
-                "within_zone_time": -0.13518
+                "time*within_zone": -0.13518
             },
             "impedance": {
                 "time": -0.13518
@@ -80,8 +80,8 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "students_comprehensive<within_municipality": 1,
-                "students_comprehensive<outside_municipality": 0.05094
+                "students_comprehensive*within_municipality": 1,
+                "students_comprehensive*outside_municipality": 0.05094
             }
         },
         "transit_work": {
@@ -95,13 +95,13 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "students_comprehensive<within_municipality": 1,
-                "students_comprehensive<outside_municipality": 0.05094
+                "students_comprehensive*within_municipality": 1,
+                "students_comprehensive*outside_municipality": 0.05094
             }
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.34315
+                "dist*within_zone": -0.34315
             },
             "impedance": {
                 "dist": -0.34315
@@ -110,13 +110,13 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "students_comprehensive<within_municipality": 1,
-                "students_comprehensive<outside_municipality": 0.05094
+                "students_comprehensive*within_municipality": 1,
+                "students_comprehensive*outside_municipality": 0.05094
             }
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.69587
+                "dist*within_zone": -0.69587
             },
             "impedance": {
                 "dist": -0.69587
@@ -125,8 +125,8 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "students_comprehensive<within_municipality": 1,
-                "students_comprehensive<outside_municipality": 0.05094
+                "students_comprehensive*within_municipality": 1,
+                "students_comprehensive*outside_municipality": 0.05094
             }
         }
     },

--- a/Scripts/parameters/demand/hb_edu_higher.json
+++ b/Scripts/parameters/demand/hb_edu_higher.json
@@ -106,7 +106,7 @@
                 "car_density": 3.78903
             },
             "attraction": {
-                "within_zone_time": -0.05519
+                "time*within_zone": -0.05519
             },
             "impedance": {
                 "time": -0.05519,
@@ -121,7 +121,7 @@
             "constant": -4.07795,
             "generation": {},
             "attraction": {
-                "within_zone_time": -0.04851
+                "time*within_zone": -0.04851
             },
             "impedance": {
                 "time": -0.04851,
@@ -153,7 +153,7 @@
             "constant": -1.24451,
             "generation": {},
             "attraction": {
-                "within_zone_dist": -0.28358
+                "dist*within_zone": -0.28358
             },
             "impedance": {
                 "dist": -0.28358
@@ -165,7 +165,7 @@
             "constant": 0,
             "generation": {},
             "attraction": {
-                "within_zone_dist": -0.48005
+                "dist*within_zone": -0.48005
             },
             "impedance": {
                 "dist": -0.48005

--- a/Scripts/parameters/demand/hb_edu_upsec.json
+++ b/Scripts/parameters/demand/hb_edu_upsec.json
@@ -89,7 +89,7 @@
     "destination_choice": {
         "car_work": {
             "attraction": {
-                "within_zone_time": -0.05109
+                "time*within_zone": -0.05109
             },
             "impedance": {
                 "time": -0.05109,
@@ -105,7 +105,7 @@
         },
         "car_pax": {
             "attraction": {
-                "within_zone_time": -0.08743
+                "time*within_zone": -0.08743
             },
             "impedance": {
                 "time": -0.08743,
@@ -137,7 +137,7 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.43169
+                "dist*within_zone": -0.43169
             },
             "impedance": {
                 "dist": -0.43169
@@ -151,7 +151,7 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.71309
+                "dist*within_zone": -0.71309
             },
             "impedance": {
                 "dist": -0.71309

--- a/Scripts/parameters/demand/hb_grocery.json
+++ b/Scripts/parameters/demand/hb_grocery.json
@@ -89,7 +89,7 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "within_zone_time": -0.08107
+                "time*within_zone": -0.08107
             },
             "impedance": {
                 "time": -0.08107,
@@ -106,7 +106,7 @@
         },
         "car_pax": {
             "attraction": {
-                "within_zone_time": -0.07494
+                "time*within_zone": -0.07494
             },
             "impedance": {
                 "time": -0.07494,
@@ -139,7 +139,7 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.35604
+                "dist*within_zone": -0.35604
             },
             "impedance": {
                 "dist": -0.35604
@@ -154,7 +154,7 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.72587
+                "dist*within_zone": -0.72587
             },
             "impedance": {
                 "dist": -0.72587

--- a/Scripts/parameters/demand/hb_leisure.json
+++ b/Scripts/parameters/demand/hb_leisure.json
@@ -89,7 +89,7 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "within_zone_time": -0.04568
+                "time*within_zone": -0.04568
             },
             "impedance": {
                 "time": -0.04568,
@@ -106,7 +106,7 @@
         },
         "car_pax": {
             "attraction": {
-                "within_zone_time": -0.04739
+                "time*within_zone": -0.04739
             },
             "impedance": {
                 "time": -0.04739,
@@ -142,7 +142,7 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.20321
+                "dist*within_zone": -0.20321
             },
             "impedance": {
                 "dist": -0.20321
@@ -157,7 +157,7 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.57219
+                "dist*within_zone": -0.57219
             },
             "impedance": {
                 "dist": -0.57219

--- a/Scripts/parameters/demand/hb_other_shop.json
+++ b/Scripts/parameters/demand/hb_other_shop.json
@@ -89,7 +89,7 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "within_zone_time": -0.0537
+                "time*within_zone": -0.0537
             },
             "impedance": {
                 "time": -0.0537,
@@ -106,7 +106,7 @@
         },
         "car_pax": {
             "attraction": {
-                "within_zone_time": -0.04923
+                "time*within_zone": -0.04923
             },
             "impedance": {
                 "time": -0.04923,
@@ -142,7 +142,7 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.26974
+                "dist*within_zone": -0.26974
             },
             "impedance": {
                 "dist": -0.26974
@@ -157,7 +157,7 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.57534
+                "dist*within_zone": -0.57534
             },
             "impedance": {
                 "dist": -0.57534

--- a/Scripts/parameters/demand/hb_sport.json
+++ b/Scripts/parameters/demand/hb_sport.json
@@ -89,7 +89,7 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "within_zone_time": -0.02561
+                "time*within_zone": -0.02561
             },
             "impedance": {
                 "time": -0.02561,
@@ -106,7 +106,7 @@
         },
         "car_pax": {
             "attraction": {
-                "within_zone_time": -0.03033
+                "time*within_zone": -0.03033
             },
             "impedance": {
                 "time": -0.03033,
@@ -140,7 +140,7 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.23737
+                "dist*within_zone": -0.23737
             },
             "impedance": {
                 "dist": -0.23737
@@ -155,7 +155,7 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.35506
+                "dist*within_zone": -0.35506
             },
             "impedance": {
                 "dist": -0.35506

--- a/Scripts/parameters/demand/hb_visit.json
+++ b/Scripts/parameters/demand/hb_visit.json
@@ -89,7 +89,7 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "within_zone_time": -0.03142
+                "time*within_zone": -0.03142
             },
             "impedance": {
                 "time": -0.03142,
@@ -105,7 +105,7 @@
         },
         "car_pax": {
             "attraction": {
-                "within_zone_time": -0.02878
+                "time*within_zone": -0.02878
             },
             "impedance": {
                 "time": -0.02878,
@@ -138,7 +138,7 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.25769
+                "dist*within_zone": -0.25769
             },
             "impedance": {
                 "dist": -0.25769
@@ -152,7 +152,7 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.52145
+                "dist*within_zone": -0.52145
             },
             "impedance": {
                 "dist": -0.52145

--- a/Scripts/parameters/demand/hb_work.json
+++ b/Scripts/parameters/demand/hb_work.json
@@ -106,7 +106,7 @@
                 "car_density": 2.97885
             },
             "attraction": {
-                "within_zone_time": -0.04168
+                "time*within_zone": -0.04168
             },
             "impedance": {
                 "time": -0.04168,
@@ -123,7 +123,7 @@
                 "car_density": 2.51359
             },
             "attraction": {
-                "within_zone_time": -0.06972
+                "time*within_zone": -0.06972
             },
             "impedance": {
                 "time": -0.06972,
@@ -155,7 +155,7 @@
             "constant": -1.11553,
             "generation": {},
             "attraction": {
-                "within_zone_dist": -0.1535
+                "dist*within_zone": -0.1535
             },
             "impedance": {
                 "dist": -0.1535
@@ -167,7 +167,7 @@
             "constant": 0,
             "generation": {},
             "attraction": {
-                "within_zone_dist": -0.45032
+                "dist*within_zone": -0.45032
             },
             "impedance": {
                 "dist": -0.45032

--- a/Scripts/parameters/demand/ob_other.json
+++ b/Scripts/parameters/demand/ob_other.json
@@ -95,7 +95,7 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "within_zone_time": -0.03129
+                "time*within_zone": -0.03129
             },
             "impedance": {
                 "time": -0.03129,
@@ -113,7 +113,7 @@
         },
         "car_pax": {
             "attraction": {
-                "within_zone_time": -0.04746
+                "time*within_zone": -0.04746
             },
             "impedance": {
                 "time": -0.04746,
@@ -149,7 +149,7 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.72027
+                "dist*within_zone": -0.72027
             },
             "impedance": {
                 "dist": -0.72027
@@ -165,7 +165,7 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.36812
+                "dist*within_zone": -0.36812
             },
             "impedance": {
                 "dist": -0.36812

--- a/Scripts/parameters/demand/wb_business.json
+++ b/Scripts/parameters/demand/wb_business.json
@@ -92,7 +92,7 @@
     "destination_choice": {
         "car_work": {
             "attraction": {
-                "within_zone_time": -0.04728
+                "time*within_zone": -0.04728
             },
             "impedance": {
                 "time": -0.04728
@@ -106,7 +106,7 @@
         },
         "car_pax": {
             "attraction": {
-                "within_zone_time": -0.04878
+                "time*within_zone": -0.04878
             },
             "impedance": {
                 "time": -0.04878
@@ -136,7 +136,7 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.11882
+                "dist*within_zone": -0.11882
             },
             "impedance": {
                 "dist": -0.11882
@@ -150,7 +150,7 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -0.61941
+                "dist*within_zone": -0.61941
             },
             "impedance": {
                 "dist": -0.61941

--- a/Scripts/parameters/demand/wb_other.json
+++ b/Scripts/parameters/demand/wb_other.json
@@ -92,7 +92,7 @@
     "destination_choice": {
         "car_leisure": {
             "attraction": {
-                "within_zone_time": -0.14388
+                "time*within_zone": -0.14388
             },
             "impedance": {
                 "time": -0.14388
@@ -108,7 +108,7 @@
         },
         "car_pax": {
             "attraction": {
-                "within_zone_time": -0.17151
+                "time*within_zone": -0.17151
             },
             "impedance": {
                 "time": -0.17151
@@ -140,7 +140,7 @@
         },
         "bike": {
             "attraction": {
-                "within_zone_dist": -0.71053
+                "dist*within_zone": -0.71053
             },
             "impedance": {
                 "dist": -0.71053
@@ -156,7 +156,7 @@
         },
         "walk": {
             "attraction": {
-                "within_zone_dist": -1.48871
+                "dist*within_zone": -1.48871
             },
             "impedance": {
                 "dist": -1.48871


### PR DESCRIPTION
The original point of this PR was to create "within_zone_dist" and "within_zone_time" matrices on the fly, because I did not want them to take up memory permanently. But then I realized that what we want to do is to multiply two variables in general, so the magic sign should be `*`. From now on, we can use it for multiplication of any two variables.