### PR TITLE
Add real-value network fields to gpkg export

### DIFF
--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -378,6 +378,8 @@ class EmmeAssignmentModel(AssignmentModel):
                 (Segment, network.transit_segments())):
             attrs = [attr.name for attr in self.day_scenario.extra_attributes()
                 if attr.type == geom_type.name]
+            attrs += [attr.name for attr in self.day_scenario.network_fields()
+                if attr.type == geom_type.name and attr.atype == "REAL"]
             resultdata.print_gpkg(
                 *geometries(attrs, objects, geom_type), fname, geom_type.name)
         log.info(f"EMME extra attributes exported to file {fname}")

--- a/Scripts/assignment/emme_bindings/mock_project.py
+++ b/Scripts/assignment/emme_bindings/mock_project.py
@@ -581,6 +581,11 @@ class Scenario:
         if idx in network._netfield[obj_type]:
             return network._netfield[obj_type][idx]
 
+    def network_fields(self):
+        network = self.get_network()
+        return (attr for attrs in network._netfield.values()
+            for attr in attrs.values())
+
     def create_extra_attribute(self,
                                obj_type: str,
                                idx: str,


### PR DESCRIPTION
Validation data has been moved to network fields, so we should output them as well.