### PR TITLE
Remove unnecessary transit and truck end assignments

### DIFF
--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -72,7 +72,7 @@ class OffPeakPeriod(AssignmentPeriod):
         del mtxs["toll_cost"]
         return mtxs
 
-    def end_assign(self) -> Dict[str, Dict[str, numpy.ndarray]]:
+    def end_assign(self) -> Dict[str, Dict[str, ndarray]]:
         """Assign bikes, cars and trucks for one time period.
 
         Get travel impedance matrices for one time period from assignment.


### PR DESCRIPTION
Transit is assigned in `init_assign` for off-peak and there is no need to iterate it. In transit-only assignment truck assignment is unnecessary.