### PR TITLE
Only create traversal files for modes with calculated demand.

### DIFF
--- a/Scripts/assignment/freight_assignment.py
+++ b/Scripts/assignment/freight_assignment.py
@@ -65,13 +65,15 @@ class FreightAssignmentPeriod(AssignmentPeriod):
         for tc in param.truck_classes:
             self.assignment_modes[tc].get_matrices()
 
-    def output_traversal_matrix(self, output_path: Path):
+    def output_traversal_matrix(self, demand_modes: set, output_path: Path):
         """Save commodity class specific auxiliary tons for freight modes.
         Result file indicates amount of transported tons with auxiliary 
         mode between gate pair.
 
         Parameters
         ----------
+        demand_modes : set
+            commodity specific demand modes
         output_path : Path
             Path where traversal matrices are saved
         """
@@ -82,7 +84,7 @@ class FreightAssignmentPeriod(AssignmentPeriod):
                 "aux_transit": param.freight_gate_attr,
             },
         }
-        for ass_class in param.freight_modes:
+        for ass_class in set(param.freight_modes) & demand_modes:
             output_file = output_path / f"{ass_class}.txt"
             spec["analyzed_demand"] = self.assignment_modes[ass_class].demand.id
             self.emme_project.traversal_analysis(

--- a/Scripts/datahandling/traversaldata.py
+++ b/Scripts/datahandling/traversaldata.py
@@ -22,7 +22,9 @@ def transform_traversal_data(result_path: Path, zones: list):
     aux_tons = numpy.zeros([len(zones), len(zones)], dtype=numpy.float32)
     for ass_class in param.freight_modes:
         file = result_path / f"{ass_class}.txt"
-        aux_tons += read_traversal_file(file, numpy.array(zones))
+        if file.exists():
+            aux_tons += read_traversal_file(file, numpy.array(zones))
+            file.unlink()
     return aux_tons
 
 def read_traversal_file(file: Path, zones: numpy.ndarray):

--- a/Scripts/freight_lem.py
+++ b/Scripts/freight_lem.py
@@ -71,7 +71,7 @@ def main(args):
                 mtx[f"{purpose}_{mode}"] = demand[mode]
         if purpose.name in args.specify_commodity_names:
             ass_model.freight_network.save_network_volumes(purpose.name)
-        ass_model.freight_network.output_traversal_matrix(resultdata.path)
+        ass_model.freight_network.output_traversal_matrix(set(demand), resultdata.path)
         demand["truck"] += transform_traversal_data(resultdata.path, zone_numbers)
         for mode in ("truck", "trailer_truck"):
             total_demand[mode] += purpose.calc_vehicles(demand["truck"], mode)

--- a/Scripts/tests/unit/test_assignment.py
+++ b/Scripts/tests/unit/test_assignment.py
@@ -110,5 +110,6 @@ class EmmeAssignmentTest(unittest.TestCase):
         for mode in ["truck", "freight_train", "ship"]:
             ass_model.freight_network.set_matrix(mode, demand)
         ass_model.freight_network.save_network_volumes("c1")
-        ass_model.freight_network.output_traversal_matrix(self.resultdata.path)
+        ass_model.freight_network.output_traversal_matrix({"freight_train", "ship"},
+                                                          self.resultdata.path)
         self.resultdata.flush()


### PR DESCRIPTION
Current traversal datahandling format does not correctly handle a situation where left over traversal txt files from previous purpose iteration are also used for next iteration purpose that might not have param.freight_modes. This is corrected by intersecting param.freight_modes and demand modes.