### PR TITLE
Add layer number check for zone data

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -255,6 +255,10 @@ def read_zonedata(path: Path,
         msg = f"Path {path} not found."
         raise NameError(msg)
     logging.getLogger("fiona").setLevel(logging.ERROR)
+    if len(fiona.listlayers(path)) > 1:
+        msg = f"Multiple layers found in file {path}"
+        log.error(msg)
+        raise TypeError(msg)
     with fiona.open(path, ignore_geometry=True) as colxn:
         data = pandas.DataFrame(
             [record["properties"] for record in colxn],


### PR DESCRIPTION
The model system will throw an error if multiple layers are detected, because in that case it is unclear which is supposed to be used. Fiona's default behavior to use the "first" layer is too ambiguous.