### PR TITLE
Clear long-dist matrices in off-peak period

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -682,7 +682,8 @@ class AssignmentPeriod(Period):
                                              / (2.0*line[effective_headway_attr]))
         self.emme_scenario.publish_network(network)
 
-    def _assign_transit(self, transit_classes=param.local_transit_classes):
+    def _assign_transit(self, transit_classes=param.local_transit_classes,
+                        add_volumes=False):
         """Perform transit assignment for one scenario."""
         self._calc_extra_wait_time()
         self._set_walk_time()
@@ -692,7 +693,8 @@ class AssignmentPeriod(Period):
             spec.init_matrices()
             self.emme_project.transit_assignment(
                 specification=spec.transit_spec, scenario=self.emme_scenario,
-                add_volumes=i, save_strategies=True, class_name=transit_class)
+                add_volumes=(i or add_volumes), save_strategies=True,
+                class_name=transit_class)
             self.emme_project.matrix_results(
                 spec.transit_result_spec, scenario=self.emme_scenario,
                 class_name=transit_class)

--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -38,9 +38,14 @@ class OffPeakPeriod(AssignmentPeriod):
         """
         self._prepare_cars(dist_unit_cost, save_matrices)
         self._prepare_walk_and_bike(save_matrices=False)
+        long_dist_transit_modes = {mode: TransitMode(
+                mode, self, day_scenario, save_matrices, save_matrices)
+            for mode in param.long_distance_transit_classes}
+        self.assignment_modes.update(long_dist_transit_modes)
         self._prepare_transit(
             day_scenario, save_standard_matrices=True,
-            save_extra_matrices=save_matrices)
+            save_extra_matrices=save_matrices,
+            transit_classes=param.local_transit_classes)
 
     def init_assign(self):
         """Assign transit for one time period with free-flow bus speed."""

--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -4,6 +4,7 @@ import copy
 
 from assignment.assignment_period import AssignmentPeriod
 from assignment.long_dist_period import WholeDayPeriod
+from assignment.datatypes.transit import TransitMode
 import parameters.assignment as param
 
 
@@ -132,9 +133,14 @@ class TransitAssignmentPeriod(OffPeakPeriod):
         """
         self._prepare_cars(dist_unit_cost, save_matrices=False)
         self._prepare_walk_and_bike(save_matrices=False)
+        long_dist_transit_modes = {mode: TransitMode(
+                mode, self, day_scenario, save_matrices, save_matrices)
+            for mode in param.long_distance_transit_classes}
+        self.assignment_modes.update(long_dist_transit_modes)
         self._prepare_transit(
             day_scenario, save_standard_matrices=True,
-            save_extra_matrices=save_matrices)
+            save_extra_matrices=save_matrices,
+            transit_classes=param.local_transit_classes)
 
     def assign_trucks_init(self):
         pass


### PR DESCRIPTION
In off-peak periods, LOS matrices are created only once and then stored in EMME for later iterations. However, it is not necessary to store LOS matrices for long-distance modes.