### PR TITLE
Add validation of long-dist base demand

### DIFF
--- a/Scripts/lem.py
+++ b/Scripts/lem.py
@@ -45,7 +45,7 @@ def main(args):
             "completed": 0,
             "failed": 0,
             "total": iterations,
-            "log": log.filename,
+            "log": str(log.filename),
             "converged": 0,
         }
     }

--- a/Scripts/lem_validate_inputfiles.py
+++ b/Scripts/lem_validate_inputfiles.py
@@ -255,7 +255,7 @@ if __name__ == "__main__":
         help="Using this flag runs only end assignment of base demand matrices.",
     )
     parser.add_argument(
-        "-f", "--long-dist-demand-forecast",
+        "-l", "--long-dist-demand-forecast",
         type=str,
         nargs="+",
         required=True,

--- a/Scripts/lem_validate_inputfiles.py
+++ b/Scripts/lem_validate_inputfiles.py
@@ -83,7 +83,7 @@ def main(args):
         # Check network
         if args.do_not_use_emme:
             mock_result_path = Path(
-                args.results_path, args.scenario_name, "Matrices",
+                args.results_path, args.scenario_name[i], "Matrices",
                 args.submodel[i])
             if not mock_result_path.exists():
                 msg = "Mock Results directory {} does not exist.".format(
@@ -192,6 +192,12 @@ def main(args):
                     for ass_class in param.transport_classes:
                         a = mtx[ass_class]
 
+    long_dist_result_paths = []
+    for name, long_dist in zip(
+            args.scenario_name, args.long_dist_demand_forecast):
+        if long_dist == "calc":
+            long_dist_result_paths.append(
+                Path(args.results_path, name, "Matrices", "koko_suomi"))
     for data_path, submodel, long_dist_forecast, freight_path in zip(
             forecast_zonedata_paths, args.submodel,
             args.long_dist_demand_forecast, args.freight_matrix_paths):
@@ -208,12 +214,14 @@ def main(args):
         if long_dist_forecast not in ("calc", "base"):
             long_dist_classes = (param.car_classes
                                  + param.long_distance_transit_classes)
-            long_dist_matrices = MatrixData(Path(long_dist_forecast))
-            with long_dist_matrices.open(
-                    "demand", "vrk", zone_numbers[submodel],
-                    forecast_zonedata.mapping, long_dist_classes) as mtx:
-                for ass_class in long_dist_classes:
-                    a = mtx[ass_class]
+            long_dist_path = Path(long_dist_forecast)
+            if long_dist_path not in long_dist_result_paths:
+                long_dist_matrices = MatrixData(long_dist_path)
+                with long_dist_matrices.open(
+                        "demand", "vrk", zone_numbers[submodel],
+                        forecast_zonedata.mapping, long_dist_classes) as mtx:
+                    for ass_class in long_dist_classes:
+                        a = mtx[ass_class]
 
         # Check freight matrices
         if freight_path != "none":
@@ -276,6 +284,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--scenario-name",
         type=str,
+        nargs="+",
+        required=True,
         help="Name of HELMET scenario. Influences result folder name and log file name."),
     parser.add_argument(
         "--results-path",

--- a/Scripts/lem_validate_inputfiles.py
+++ b/Scripts/lem_validate_inputfiles.py
@@ -208,7 +208,7 @@ def main(args):
         if long_dist_forecast not in ("calc", "base"):
             long_dist_classes = (param.car_classes
                                  + param.long_distance_transit_classes)
-            long_dist_matrices = MatrixData(long_dist_forecast)
+            long_dist_matrices = MatrixData(Path(long_dist_forecast))
             with long_dist_matrices.open(
                     "demand", "vrk", zone_numbers[submodel],
                     forecast_zonedata.mapping, long_dist_classes) as mtx:
@@ -217,7 +217,7 @@ def main(args):
 
         # Check freight matrices
         if freight_path != "none":
-            freight_matrices = MatrixData(freight_path)
+            freight_matrices = MatrixData(Path(freight_path))
             with freight_matrices.open(
                     "demand", "vrk", zone_numbers[submodel],
                     forecast_zonedata.mapping, param.truck_classes) as mtx:

--- a/Scripts/lem_validate_inputfiles.py
+++ b/Scripts/lem_validate_inputfiles.py
@@ -192,9 +192,9 @@ def main(args):
                     for ass_class in param.transport_classes:
                         a = mtx[ass_class]
 
-    for data_path, submodel, long_dist_forecast in zip(
+    for data_path, submodel, long_dist_forecast, freight_path in zip(
             forecast_zonedata_paths, args.submodel,
-            args.long_dist_demand_forecast):
+            args.long_dist_demand_forecast, args.freight_matrix_paths):
         # Check forecasted zonedata
         if not os.path.exists(data_path):
             msg = "Forecast data file '{}' does not exist.".format(
@@ -213,6 +213,15 @@ def main(args):
                     "demand", "vrk", zone_numbers[submodel],
                     forecast_zonedata.mapping, long_dist_classes) as mtx:
                 for ass_class in long_dist_classes:
+                    a = mtx[ass_class]
+
+        # Check freight matrices
+        if freight_path is not None:
+            freight_matrices = MatrixData(freight_path)
+            with freight_matrices.open(
+                    "demand", "vrk", zone_numbers[submodel],
+                    forecast_zonedata.mapping, param.truck_classes) as mtx:
+                for ass_class in param.truck_classes:
                     a = mtx[ass_class]
 
     log.info("Successfully validated all input files")
@@ -238,7 +247,7 @@ if __name__ == "__main__":
         help="Using this flag runs only end assignment of base demand matrices.",
     )
     parser.add_argument(
-        "-f", "--long-dist-demand-forecasts",
+        "-f", "--long-dist-demand-forecast",
         type=str,
         nargs="+",
         required=True,
@@ -246,6 +255,12 @@ if __name__ == "__main__":
               + "calculates demand for long-distance trips. "
               + "If 'base', takes long-distance trips from base matrices. "
               + "If path, takes long-distance trips from that path.")
+    )
+    parser.add_argument(
+        "-f", "--freight-matrix-paths",
+        type=str,
+        nargs="+",
+        help=("If specified, take freight demand matrices from path.")
     )
     parser.add_argument(
         "--do-not-use-emme",

--- a/Scripts/lem_validate_inputfiles.py
+++ b/Scripts/lem_validate_inputfiles.py
@@ -216,7 +216,7 @@ def main(args):
                     a = mtx[ass_class]
 
         # Check freight matrices
-        if freight_path is not None:
+        if freight_path != "none":
             freight_matrices = MatrixData(freight_path)
             with freight_matrices.open(
                     "demand", "vrk", zone_numbers[submodel],
@@ -260,6 +260,7 @@ if __name__ == "__main__":
         "-f", "--freight-matrix-paths",
         type=str,
         nargs="+",
+        required=True,
         help=("If specified, take freight demand matrices from path.")
     )
     parser.add_argument(

--- a/Scripts/tests/integration/test_helmet_validation.py
+++ b/Scripts/tests/integration/test_helmet_validation.py
@@ -18,7 +18,8 @@ class Args:
     results_path = TEST_DATA_PATH / "Results"
     scenario_name = "test"
     do_not_use_emme = True
-    long_dist_demand_forecast = None
+    long_dist_demand_forecast = ["base"]
+    freight_matrix_paths = [None]
     submodel = ["uusimaa"]
 
 

--- a/Scripts/tests/integration/test_helmet_validation.py
+++ b/Scripts/tests/integration/test_helmet_validation.py
@@ -19,7 +19,7 @@ class Args:
     scenario_name = "test"
     do_not_use_emme = True
     long_dist_demand_forecast = ["base"]
-    freight_matrix_paths = [None]
+    freight_matrix_paths = ["none"]
     submodel = ["uusimaa"]
 
 

--- a/Scripts/tests/integration/test_helmet_validation.py
+++ b/Scripts/tests/integration/test_helmet_validation.py
@@ -16,7 +16,7 @@ class Args:
     forecast_data_paths = [ZONEDATA_PATH]
     cost_data_paths = [COSTDATA_PATH]
     results_path = TEST_DATA_PATH / "Results"
-    scenario_name = "test"
+    scenario_name = ["test"]
     do_not_use_emme = True
     long_dist_demand_forecast = ["base"]
     freight_matrix_paths = ["none"]

--- a/Scripts/utils/log.py
+++ b/Scripts/utils/log.py
@@ -1,5 +1,5 @@
-import os
 import sys
+from pathlib import Path
 import json
 import logging
 import logging.handlers
@@ -31,12 +31,12 @@ def initialize(args):
             format='%(asctime)s [%(levelname)s] %(message)s',
             datefmt='%Y-%m-%d %H:%M:%S',)
     # Rotating file logger
-    file = args.scenario_name + ".log"
-    result_dir = os.path.join(args.results_path, args.scenario_name)
-    if not os.path.exists(result_dir):
-        os.makedirs(result_dir)
+    scenario_name = (args.scenario_name
+        if isinstance(args.scenario_name, str) else args.scenario_name[0])
+    result_dir = Path(args.results_path, scenario_name)
+    result_dir.mkdir(parents=True, exist_ok=True)
     global filename
-    filename = os.path.join(result_dir, file)
+    filename = result_dir / f"{scenario_name}.log"
     fileFormat = logging.Formatter(
         '%(asctime)s [%(levelname)s] %(message)s', '%Y-%m-%d %H:%M:%S')
     fileHandler = logging.handlers.TimedRotatingFileHandler(


### PR DESCRIPTION
If a path for long-distance demand matrices is given, `lem_validate_inputfiles.py` checks that either of the following applies:

1. The matrices exist and have correct zone numbers.
2. A long-distance demand calculation, which will save results in the given path, is scheduled.

For freight demand matrices, we currently check that they exist. We could later add the possibility that they are scheduled to be created.