### PR TITLE
Restore full transit end assignment in OffPeakPeriod

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -694,8 +694,7 @@ class AssignmentPeriod(Period):
                                              / (2.0*line[effective_headway_attr]))
         self.emme_scenario.publish_network(network)
 
-    def _assign_transit(self, transit_classes=param.local_transit_classes,
-                        add_volumes=False):
+    def _assign_transit(self, transit_classes=param.local_transit_classes):
         """Perform transit assignment for one scenario."""
         self._calc_extra_wait_time()
         self._set_walk_time()
@@ -705,8 +704,7 @@ class AssignmentPeriod(Period):
             spec.init_matrices()
             self.emme_project.transit_assignment(
                 specification=spec.transit_spec, scenario=self.emme_scenario,
-                add_volumes=(i or add_volumes), save_strategies=True,
-                class_name=transit_class)
+                add_volumes=i, save_strategies=True, class_name=transit_class)
             self.emme_project.matrix_results(
                 spec.transit_result_spec, scenario=self.emme_scenario,
                 class_name=transit_class)

--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -86,31 +86,6 @@ class OffPeakPeriod(AssignmentPeriod):
         del mtxs["toll_cost"]
         return mtxs
 
-    def end_assign(self) -> Dict[str, Dict[str, ndarray]]:
-        """Assign bikes, cars and trucks for one time period.
-
-        Get travel impedance matrices for one time period from assignment.
-        Transit impedance is fetched from free-flow init assignment.
-
-        Returns
-        -------
-        dict
-            Type (time/cost/dist) : dict
-                Assignment class (car_work/transit/...) : numpy 2-d matrix
-        """
-        self._set_bike_vdfs()
-        self._assign_bikes()
-        self._set_car_vdfs()
-        if not self._separate_emme_scenarios:
-            self._calc_background_traffic(include_trucks=True)
-        self._assign_cars(self.stopping_criteria["fine"])
-        self._set_car_vdfs(use_free_flow_speeds=True)
-        self._assign_trucks()
-        self._assign_transit(
-            param.long_distance_transit_classes, add_volumes=True)
-        self._calc_transit_network_results()
-        return self._get_impedances(self._end_assignment_classes)
-
 
 class TransitAssignmentPeriod(OffPeakPeriod):
     """Transit-only assignment period.
@@ -172,8 +147,7 @@ class TransitAssignmentPeriod(OffPeakPeriod):
             Type (time/cost/dist) : dict
                 Assignment class (transit_work/...) : numpy 2-d matrix
         """
-        self._assign_transit(
-            param.long_distance_transit_classes, add_volumes=True)
+        self._assign_transit(param.transit_classes)
         self._calc_transit_network_results()
         self._end_assignment_classes -= set(
             param.private_classes + param.truck_classes)


### PR DESCRIPTION
For a while, only long-distance transit modes have been assigned in last assignment in `OffPeakPeriod` and `TransitAssignmentPeriod`, and short distance transit results have been fetched from assignment initialization. However, this does not work when all periods are in the same EMME scenario, because the short-distance assignment results are overwritten by the other assignment periods.

Now I restored assignment of all transit modes in end assignment. However, the assignment is still faster than it was a month ago, because long-distance transit is no longer assigned in the initialization phase.