### PR TITLE
Add geometry-type specific fixed attributes to gpkg output

### DIFF
--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -387,6 +387,7 @@ class EmmeAssignmentModel(AssignmentModel):
                 if attr.type == geom_type.name]
             attrs += [attr.name for attr in self.day_scenario.network_fields()
                 if attr.type == geom_type.name and attr.atype == "REAL"]
+            attrs += geom_type.attrs
             resultdata.print_gpkg(
                 *geometries(attrs, objects, geom_type), fname, geom_type.name)
         log.info(f"EMME extra attributes exported to file {fname}")

--- a/Scripts/utils/print_links.py
+++ b/Scripts/utils/print_links.py
@@ -7,6 +7,8 @@ from utils.calc_noise import NoiseModel
 class GeometryType:
     name: str
     geom_type: str
+    attrs = ["data1", "data2", "data3"]
+
     def __new__(cls, obj):
         pass
 
@@ -22,6 +24,7 @@ class Node(GeometryType):
 class Link(GeometryType):
     name = "LINK"
     geom_type = "LineString"
+    attrs = GeometryType.attrs + ["type",  "num_lanes", "volume_delay_func"]
 
     def __new__(cls, link):
         return LineString(link.shape)
@@ -60,14 +63,14 @@ def geometries(attr_names: Iterable[str],
         "geometry": geom_type(obj),
         "properties": {
             "id": obj.id,
-            **{attr[1:]: obj[attr] for attr in attr_names},
+            **{attr.lstrip("@#"): obj[attr] for attr in attr_names},
         }
     } for obj in objects)
     schema = {
         "geometry": geom_type.geom_type,
         "properties": {
             "id": "str",
-            **{attr[1:]: "float" for attr in attr_names}
+            **{attr.lstrip("@#"): "float" for attr in attr_names}
         }
     }
     return recs, schema


### PR DESCRIPTION
More attributes can easily be added to output by adding them to `attrs`.

Link modes are unfortunately not possible to output with this approach, as they are not an "attribute" in EMME. They would require a considerable amount of extra code to include.