### PR TITLE
Make car assignment sequential when `use_stored_speeds`

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -569,7 +569,7 @@ class AssignmentPeriod(Period):
         """Perform car_work traffic assignment for one scenario."""
         log.info("Car assignment started...")
         if self.use_stored_speeds:
-            for car_spec in self._car_spec.light_separate_specs():
+            for car_spec in self._car_spec.separate_light_specs():
                 car_spec["stopping_criteria"] = stopping_criteria
                 self.emme_project.car_assignment(car_spec, self.emme_scenario)
         else:

--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -595,12 +595,12 @@ class AssignmentPeriod(Period):
             self.emme_scenario.id))
 
     def _assign_trucks(self):
-        truck_spec = self._car_spec.truck_spec()
         stopping_criteria = copy.deepcopy(param.stopping_criteria["coarse"])
         stopping_criteria["max_iterations"] = 0
-        truck_spec["stopping_criteria"] = stopping_criteria
-        self.emme_project.car_assignment(
-            truck_spec, self.emme_scenario)
+        for truck_spec in self._car_spec.truck_specs():
+            truck_spec["stopping_criteria"] = stopping_criteria
+            self.emme_project.car_assignment(
+                truck_spec, self.emme_scenario)
         log.info("Truck assignment performed for scenario {}".format(
             self.emme_scenario.id))
 

--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -568,10 +568,21 @@ class AssignmentPeriod(Period):
                      stopping_criteria: Dict[str, Union[int, float]]):
         """Perform car_work traffic assignment for one scenario."""
         log.info("Car assignment started...")
-        car_spec = self._car_spec.light_spec()
-        car_spec["stopping_criteria"] = stopping_criteria
-        assign_report = self.emme_project.car_assignment(
-            car_spec, self.emme_scenario)
+        if self.use_stored_speeds:
+            for car_spec in self._car_spec.light_separate_specs():
+                car_spec["stopping_criteria"] = stopping_criteria
+                self.emme_project.car_assignment(car_spec, self.emme_scenario)
+        else:
+            car_spec = self._car_spec.light_spec()
+            car_spec["stopping_criteria"] = stopping_criteria
+            assign_report = self.emme_project.car_assignment(
+                car_spec, self.emme_scenario)
+            log.info("Stopping criteria: {}, iteration {} / {}".format(
+                assign_report["stopping_criterion"],
+                len(assign_report["iterations"]),
+                stopping_criteria["max_iterations"]))
+            if assign_report["stopping_criterion"] == "MAX_ITERATIONS":
+                log.warn("Car assignment not fully converged.")
         network = self.emme_scenario.get_network()
         time_attr = self.netfield("car_time")
         truck_time_attr = self.extra("truck_time")
@@ -582,13 +593,6 @@ class AssignmentPeriod(Period):
         self.emme_scenario.publish_network(network)
         log.info("Car assignment performed for scenario {}".format(
             self.emme_scenario.id))
-        log.info("Stopping criteria: {}, iteration {} / {}".format(
-            assign_report["stopping_criterion"],
-            len(assign_report["iterations"]),
-            stopping_criteria["max_iterations"]
-            ))
-        if assign_report["stopping_criterion"] == "MAX_ITERATIONS":
-            log.warn("Car assignment not fully converged.")
 
     def _assign_trucks(self):
         truck_spec = self._car_spec.truck_spec()

--- a/Scripts/assignment/datatypes/car_specification.py
+++ b/Scripts/assignment/datatypes/car_specification.py
@@ -36,6 +36,12 @@ class CarSpecification:
         self._spec["classes"] = specs
         return self._spec
 
+    def light_separate_specs(self):
+        for mode in param.car_and_van_classes:
+            self._modes[mode].init_matrices()
+            self._spec["classes"] = [self._modes[mode].spec]
+            yield self._spec
+
     def truck_spec(self) -> Dict[str, Any]:
         specs = []
         for mode in param.truck_classes:

--- a/Scripts/assignment/datatypes/car_specification.py
+++ b/Scripts/assignment/datatypes/car_specification.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Dict
+from typing import Any, Dict, Generator
 import parameters.assignment as param
 from assignment.datatypes.car import CarMode
 
@@ -29,6 +29,7 @@ class CarSpecification:
         }
 
     def light_spec(self) -> Dict[str, Any]:
+        """Return light vehicle assignment specification."""
         specs = []
         for mode in param.car_and_van_classes:
             self._modes[mode].init_matrices()
@@ -36,13 +37,20 @@ class CarSpecification:
         self._spec["classes"] = specs
         return self._spec
 
-    def light_separate_specs(self):
+    def separate_light_specs(self) -> Generator[Dict[str, Any]]:
+        """Yield light vehicle assignment specifications.
+
+        Can be used for assigning car modes sequentially,
+        without congestion.
+        """
         for mode in param.car_and_van_classes:
-            self._modes[mode].init_matrices()
-            self._spec["classes"] = [self._modes[mode].spec]
-            yield self._spec
+            if mode in self._modes:
+                self._modes[mode].init_matrices()
+                self._spec["classes"] = [self._modes[mode].spec]
+                yield self._spec
 
     def truck_spec(self) -> Dict[str, Any]:
+        """Return truck assignment specification."""
         specs = []
         for mode in param.truck_classes:
             self._modes[mode].init_matrices()

--- a/Scripts/assignment/datatypes/car_specification.py
+++ b/Scripts/assignment/datatypes/car_specification.py
@@ -49,12 +49,9 @@ class CarSpecification:
                 self._spec["classes"] = [self._modes[mode].spec]
                 yield self._spec
 
-    def truck_spec(self) -> Dict[str, Any]:
-        """Return truck assignment specification."""
-        specs = []
+    def truck_specs(self) -> Generator[Dict[str, Any]]:
+        """Yield truck assignment specifications."""
         for mode in param.truck_classes:
             self._modes[mode].init_matrices()
-            specs.append(self._modes[mode].spec)
-        self._spec["classes"] = specs
-        return self._spec
-
+            self._spec["classes"] = [self._modes[mode].spec]
+            yield self._spec

--- a/Scripts/assignment/freight_assignment.py
+++ b/Scripts/assignment/freight_assignment.py
@@ -59,11 +59,11 @@ class FreightAssignmentPeriod(AssignmentPeriod):
             spec["on_links"]["aux_transit_volumes"] = "@a_" + attr_name
             self.emme_project.network_results(
                 spec, self.emme_scenario, ass_class)
-        spec = self._car_spec.truck_spec()
         attr_name = (commodity_class + "truck")[:17]
-        spec["classes"][0]["results"]["link_volumes"] = "@" + attr_name
-        spec["stopping_criteria"] = self.stopping_criteria["coarse"]
-        self.emme_project.car_assignment(spec, self.emme_scenario)
+        for spec in self._car_spec.truck_specs():
+            spec["classes"][0]["results"]["link_volumes"] = "@" + attr_name
+            spec["stopping_criteria"] = self.stopping_criteria["coarse"]
+            self.emme_project.car_assignment(spec, self.emme_scenario)
         for tc in param.truck_classes:
             self.assignment_modes[tc].get_matrices()
 


### PR DESCRIPTION
With more than 9,000 zones, adding more assignment classes seems to be causing memory issues in car assignment. Because we do not use congested assignment for this large network, we do not have to assign all classes simultaneously. This PR applies a sequential assignment process when `use_stored_speeds` is enabled.