### PR TITLE
Add mode impedance validation

### DIFF
--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -473,6 +473,9 @@ class ModeDestModel(LogitModel):
                         ) -> Dict[str, numpy.ndarray]:
         dummies: defaultdict[str, list] = defaultdict(list)
         for mode in self.mode_choice_param:
+            if mode not in mode_exps:
+                msg = f"Mode {mode} missing from {self.purpose.name} impedance"
+                raise KeyError(msg)
             for i in self.mode_choice_param[mode]["individual_dummy"]:
                 dummies[i].append(mode)
         mode_probs: defaultdict[str, list] = defaultdict(list)


### PR DESCRIPTION
Mode definition in `LogitModel` has become more and more implicit in previous changes. It has now become so implicit, that demand calculation can continue quite bit even with missing modes in LOS matrices (which can be an issue when using `MockAssignmentModel`). I added this checkpoint to make debugging easier.