### PR TITLE
Fix actual aux transit cost result spec nesting level

### DIFF
--- a/Scripts/assignment/datatypes/freight_specification.py
+++ b/Scripts/assignment/datatypes/freight_specification.py
@@ -105,7 +105,7 @@ class FreightMode(AssignmentMode):
             self.spec["aux_transit_by_mode"][0]["cost"] = "@toll_cost_vrk"
             self.spec["aux_transit_by_mode"][0]["cost_perception_factor"] = 1.0
             self.toll_cost = self._create_matrix("toll_cost")
-            self.local_result_spec["actual_aux_transit_costs"] = self.toll_cost.id
+            self.local_result_spec["by_mode_subset"]["actual_aux_transit_costs"] = self.toll_cost.id
         self.ntw_results_spec = {
             "type": "EXTENDED_TRANSIT_NETWORK_RESULTS",
             "analyzed_demand": self.demand.id,


### PR DESCRIPTION
Fix for moving toll cost mf id to correct nesting level for local_result_spec in freight spec. Otherwise Emme raises type error on matrix_results func with local_result_spec