### PR TITLE
Make car-ownership model more robust to very bad accessibility

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -252,6 +252,9 @@ class AssignmentPeriod(Period):
                     f"OD speed (km/h) {mode}")
             except KeyError:
                 pass
+            for mtx_type, mtx in mtxs[mode].items():
+                if numpy.any(mtx > 1e10):
+                    log.warn(f"Matrix with infinite values: {mtx_type} {mode}")
         impedance = {mtx_type: {mode: mtxs[mode][mtx_type]
                 for mode in mtxs if mtx_type in mtxs[mode]}
             for mtx_type in param.impedance_output}

--- a/Scripts/models/car_ownership.py
+++ b/Scripts/models/car_ownership.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
 from models.logit import LogitModel, divide
 from utils.calibrate import attempt_calibration
+import utils.log as log
 
 
 class CarOwnershipModel(LogitModel):
@@ -47,8 +48,8 @@ class CarOwnershipModel(LogitModel):
             utility = numpy.zeros(self.bounds.stop, dtype=numpy.float32)
             self._add_constant(utility, b["constant"])
             utility = self._add_zone_util(utility, b["generation"], True)
-            self.exps[nr_cars] = numpy.exp(utility)
-            nr_cars_expsum += numpy.exp(utility)
+            self.exps[nr_cars] = numpy.minimum(numpy.exp(utility), 99999)
+            nr_cars_expsum += self.exps[nr_cars]
         for nr_cars in self.param:
             prob[nr_cars] = divide(self.exps[nr_cars], nr_cars_expsum)
         return prob

--- a/Scripts/models/car_ownership.py
+++ b/Scripts/models/car_ownership.py
@@ -7,7 +7,6 @@ if TYPE_CHECKING:
 
 from models.logit import LogitModel, divide
 from utils.calibrate import attempt_calibration
-import utils.log as log
 
 
 class CarOwnershipModel(LogitModel):


### PR DESCRIPTION
Logsums can sometimes be very negative or even `-inf`, which is perfectly fine, as it represents little or no accessibility and causes zero probabilities in destination and mode choice. But this causes problems in car-ownership model, as accessibility affects car ownership utility *negatively*. We easily end up with `exp(utility)` being `inf`, which messes up the probability calculation (`inf/inf=nan`).

Now I solved this by setting an upper limit for `exp(utility)`.

I also restored the `inf` LOS matrix warning that was lost in #123.