### PR TITLE
Remove separate `AccessibilityModel`

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -255,10 +255,8 @@ class TourPurpose(Purpose):
             self.model = logit.OriginModel(*args)
         elif specification["struct"] == "dest>mode":
             self.model = logit.DestModeModel(*args)
-            self.accessibility_model = self.model
         else:
             self.model = logit.ModeDestModel(*args)
-            self.accessibility_model = logit.AccessibilityModel(*args)
         for mode in self.demand_share:
             self.demand_share[mode]["vrk"] = [1, 1]
         self.modes = list(self.model.mode_choice_param)
@@ -328,8 +326,7 @@ class TourPurpose(Purpose):
                     Mode (bike/walk) : numpy.ndarray
         """
         purpose_impedance = self.transform_impedance(impedance)
-        self.model.calc_soft_mode_exps(copy(purpose_impedance))
-        self.accessibility_model.calc_soft_mode_exps(purpose_impedance)
+        self.model.calc_soft_mode_exps(purpose_impedance)
 
     def calc_prob(self, impedance, is_last_iteration):
         """Calculate mode and destination probabilities.
@@ -342,10 +339,7 @@ class TourPurpose(Purpose):
                     Mode (car/transit/bike/...) : numpy.ndarray
         """
         purpose_impedance = self.transform_impedance(impedance)
-        if is_last_iteration:
-            self.accessibility_model.calc_accessibility(
-                copy(purpose_impedance))
-        self.prob = self.model.calc_prob(purpose_impedance)
+        self.prob = self.model.calc_prob(purpose_impedance, is_last_iteration)
         log.info(f"Mode and dest probabilities calculated for {self.name}")
 
     def calc_basic_prob(self, impedance, is_last_iteration):
@@ -368,10 +362,8 @@ class TourPurpose(Purpose):
             Empty list
         """
         purpose_impedance = self.transform_impedance(impedance)
-        if is_last_iteration and self.name[0] != 's':
-            self.accessibility_model.calc_accessibility(
-                copy(purpose_impedance))
-        self.model.calc_basic_prob(purpose_impedance)
+        self.model.calc_basic_prob(
+            purpose_impedance, is_last_iteration and self.name[0] != 's')
         log.info(f"Mode and dest probabilities calculated for {self.name}")
         return []
 

--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -217,7 +217,7 @@ class DemandModel:
             return
         log.info("Calc car ownership based on hb_leisure accessibility...")
         purpose_impedance = acc_purpose.transform_impedance(impedance)
-        acc_purpose.accessibility_model.calc_accessibility(purpose_impedance)
+        acc_purpose.model.calc_prob(purpose_impedance, calc_accessibility=True)
         zd = self.zone_data
         prob = {hh_size: model.calc_prob()
             for hh_size, model in self.car_ownership_models.items()}

--- a/Scripts/modelsystem.py
+++ b/Scripts/modelsystem.py
@@ -444,8 +444,7 @@ class ModelSystem:
 
     def _export_accessibility(self):
         for purpose in self.dm.tour_purposes:
-            accessibility = purpose.accessibility_model.accessibility
-            for logsum in accessibility.values():
+            for logsum in purpose.model.accessibility.values():
                 self.resultdata.print_data(logsum, f"accessibility.txt")
     
     def _export_model_results(self):


### PR DESCRIPTION
After geographic sub-bounds were removed in #192, the separate `AccessibilityModel` is no longer needed. I moved `calc_accessibility()` to the regular probability calculation as an optional extra calculation step.