### PR TITLE
Fix transit network result attributes

### DIFF
--- a/Scripts/assignment/datatypes/transit.py
+++ b/Scripts/assignment/datatypes/transit.py
@@ -39,7 +39,7 @@ class TransitMode(AssignmentMode):
         self.segment_results: Dict[str, str] = {}
         self.node_results: Dict[str, str] = {}
         for scenario, tp in (
-                (self.emme_scenario, self.time_period), (day_scenario, "vrk")):
+                (day_scenario, "vrk"), (self.emme_scenario, self.time_period)):
             for res, attr in param.segment_results.items():
                 attr_name = f"@{self.name[:11]}_{attr}_{tp}"
                 self.segment_results[res] = attr_name


### PR DESCRIPTION
By accident, we have written all transit network results to "vrk" attributes, so in result aggregations there has been no time-period results to aggregate, except if there has been some old results.