### PR TITLE
Update long tour demand model parameters

### DIFF
--- a/Scripts/parameters/demand/hb_business_long.json
+++ b/Scripts/parameters/demand/hb_business_long.json
@@ -62,8 +62,8 @@
         "airplane": {
             "attraction": {},
             "impedance": {
-                "time": -0.00058,
-                "cost": -0.00055
+                "time": -0.0006,
+                "cost": -0.00125
             },
             "log": {
                 "attraction_size": 1
@@ -75,8 +75,8 @@
         "train": {
             "attraction": {},
             "impedance": {
-                "time": -0.00138,
-                "cost": -0.00055
+                "time": -0.00102,
+                "cost": -0.00125
             },
             "log": {
                 "attraction_size": 1
@@ -88,8 +88,8 @@
         "long_d_bus": {
             "attraction": {},
             "impedance": {
-                "time": -0.00316,
-                "cost": -0.00055
+                "time": -0.00266,
+                "cost": -0.00125
             },
             "log": {
                 "attraction_size": 1
@@ -101,8 +101,8 @@
         "car_work": {
             "attraction": {},
             "impedance": {
-                "time": -0.00747,
-                "cost": -0.00055
+                "time": -0.00608,
+                "cost": -0.00125
             },
             "log": {
                 "attraction_size": 1
@@ -114,8 +114,8 @@
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.00523,
-                "cost": -0.00055
+                "time": -0.0052,
+                "cost": -0.00125
             },
             "log": {
                 "attraction_size": 1
@@ -132,81 +132,81 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.49528
+                "logsum": 0.71727
             },
             "individual_dummy": {}
         },
         "train": {
-            "constant": 2.21259,
+            "constant": 0.71511,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.49528
+                "logsum": 0.71727
             },
             "individual_dummy": {}
         },
         "long_d_bus": {
-            "constant": 1.70276,
+            "constant": 0.57099,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.49528
+                "logsum": 0.71727
             },
             "individual_dummy": {}
         },
         "car_work": {
-            "constant": 1.08824,
+            "constant": 0.95439,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.49528
+                "logsum": 0.71727
             },
             "individual_dummy": {
-                "sh_cars1_hh1": 4.9826,
-                "sh_cars2_hh2": 4.9826,
-                "sh_cars1_hh2": 3.86877
+                "sh_cars1_hh1": 2.96762,
+                "sh_cars2_hh2": 2.96762,
+                "sh_cars1_hh2": 1.94551
             }
         },
         "car_pax": {
-            "constant": 1.8833,
+            "constant": 1.50871,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.49528
+                "logsum": 0.71727
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 0.28435,
-                "sh_cars2_hh2": 0.28435
+                "sh_cars1_hh2": -0.3803,
+                "sh_cars2_hh2": -0.3803
             }
         },
         "scaling": {
             "car_work": {
-                "constant": 0.49528,
+                "constant": 0.71727,
                 "individual_dummy": {
-                    "sh_cars1_hh1": 0.49528,
-                    "sh_cars2_hh2": 0.49528,
-                    "sh_cars1_hh2": 0.49528
+                    "sh_cars1_hh1": 0.71727,
+                    "sh_cars2_hh2": 0.71727,
+                    "sh_cars1_hh2": 0.71727
                 }
             },
             "car_pax": {
-                "constant": 0.49528,
+                "constant": 0.71727,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.49528,
-                    "sh_cars2_hh2": 0.49528
+                    "sh_cars1_hh2": 0.71727,
+                    "sh_cars2_hh2": 0.71727
                 }
             },
             "train": {
-                "constant": 0.49528
+                "constant": 0.71727
             },
             "long_d_bus": {
-                "constant": 0.49528
+                "constant": 0.71727
             },
             "airplane": {
-                "constant": 0.49528
+                "constant": 0.71727
             }
         }
     },

--- a/Scripts/parameters/demand/hb_private_day.json
+++ b/Scripts/parameters/demand/hb_private_day.json
@@ -17,12 +17,6 @@
                 1.0
               ]
             },
-        "airplane": {
-            "vrk": [
-                1.0,
-                1.0
-              ]
-            },
         "train": {
             "vrk": [
                 1.0,
@@ -45,10 +39,6 @@
             100,
             9999
         ],
-        "airplane": [
-            100,
-            9999
-        ],
         "train": [
             100,
             9999
@@ -59,159 +49,129 @@
         ]
     },
     "destination_choice": {
-        "airplane": {
-            "attraction": {},
-            "impedance": {
-                "time": -0.00414,
-                "cost": -0.02813
-            },
-            "log": {
-                "attraction_size": 1
-            },
-            "attraction_size": {
-                "population": 1,
-                "recreation": 23.26779
-            }
-        },
         "train": {
             "attraction": {},
             "impedance": {
-                "time": -0.00108,
-                "cost": -0.02813
+                "time": -0.00025,
+                "cost": -0.02855
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "population": 1,
-                "recreation": 23.26779
+                "recreation": 35.74856
             }
         },
         "long_d_bus": {
             "attraction": {},
             "impedance": {
-                "time": -0.00153,
-                "cost": -0.02813
+                "time": -0.00191,
+                "cost": -0.02855
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "population": 1,
-                "recreation": 23.26779
+                "recreation": 35.74856
             }
         },
         "car_leisure": {
             "attraction": {},
             "impedance": {
-                "time": -0.00661,
-                "cost": -0.02813
+                "time": -0.00552,
+                "cost": -0.02855
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "population": 1,
-                "recreation": 23.26779
+                "recreation": 35.74856
             }
         },
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.0102,
-                "cost": -0.02813
+                "time": -0.00818,
+                "cost": -0.02855
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "population": 1,
-                "recreation": 23.26779
+                "recreation": 35.74856
             }
         }
     },
     "mode_choice": {
-        "airplane": {
+        "train": {
             "constant": 0,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.31979
-            },
-            "individual_dummy": {}
-        },
-        "train": {
-            "constant": -2.41899,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 0.31979
+                "logsum": 1
             },
             "individual_dummy": {}
         },
         "long_d_bus": {
-            "constant": 0.19824,
+            "constant": 1.78744,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.31979
+                "logsum": 1
             },
             "individual_dummy": {}
         },
         "car_leisure": {
-            "constant": 0.28162,
+            "constant": 1.3049,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.31979
+                "logsum": 1
             },
             "individual_dummy": {
-                "sh_cars1_hh1": 6.7855,
-                "sh_cars2_hh2": 6.7855,
-                "sh_cars1_hh2": 5.71598
+                "sh_cars1_hh1": 2.40277,
+                "sh_cars2_hh2": 2.40277,
+                "sh_cars1_hh2": 2.26578
             }
         },
         "car_pax": {
-            "constant": 2.31885,
+            "constant": 1.98432,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.31979
+                "logsum": 1
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 3.22658,
-                "sh_cars2_hh2": 3.22658
+                "sh_cars1_hh2": 1.15115,
+                "sh_cars2_hh2": 1.15115
             }
         },
         "scaling": {
             "car_leisure": {
-                "constant": 0.31979,
+                "constant": 1,
                 "individual_dummy": {
-                    "sh_cars1_hh1": 0.31979,
-                    "sh_cars2_hh2": 0.31979,
-                    "sh_cars1_hh2": 0.31979
+                    "sh_cars1_hh1": 1,
+                    "sh_cars2_hh2": 1,
+                    "sh_cars1_hh2": 1
                 }
             },
             "car_pax": {
-                "constant": 0.31979,
+                "constant": 1,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.31979,
-                    "sh_cars2_hh2": 0.31979
+                    "sh_cars1_hh2": 1,
+                    "sh_cars2_hh2": 1
                 }
             },
-            "airplane": {
-                "constant": 0.31979
-            },
-            "train": {
-                "constant": 0.31979
-            },
             "long_d_bus": {
-                "constant": 0.31979
+                "constant": 1
             }
         }
     },
@@ -223,12 +183,6 @@
               ]
         },
         "car_pax": {
-            "vrk": [
-                1.0,
-                1.0
-              ]
-        },
-        "airplane": {
             "vrk": [
                 1.0,
                 1.0

--- a/Scripts/parameters/demand/hb_private_week.json
+++ b/Scripts/parameters/demand/hb_private_week.json
@@ -61,82 +61,82 @@
     "destination_choice": {
         "airplane": {
             "attraction": {
-                "Lappi": 1.30889
+                "Lappi": 1.33213
             },
             "impedance": {
-                "time": -0.00072,
-                "cost": -0.00184
+                "time": -0.00069,
+                "cost": -0.00247
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "area_leisure_buildings": 1,
-                "hospitality": 452.6232
+                "hospitality": 439.06611
             }
         },
         "train": {
             "attraction": {
-                "Lappi": 1.30889
+                "Lappi": 1.33213
             },
             "impedance": {
                 "time": -0.00045,
-                "cost": -0.00184
+                "cost": -0.00247
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "area_leisure_buildings": 1,
-                "hospitality": 452.6232
+                "hospitality": 439.06611
             }
         },
         "long_d_bus": {
             "attraction": {
-                "Lappi": 1.30889
+                "Lappi": 1.33213
             },
             "impedance": {
-                "time": -0.00261,
-                "cost": -0.00184
+                "time": -0.00241,
+                "cost": -0.00247
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "area_leisure_buildings": 1,
-                "hospitality": 452.6232
+                "hospitality": 439.06611
             }
         },
         "car_leisure": {
             "attraction": {
-                "Lappi": 1.30889
+                "Lappi": 1.33213
             },
             "impedance": {
-                "time": -0.00307,
-                "cost": -0.00184
+                "time": -0.00317,
+                "cost": -0.00247
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "area_leisure_buildings": 1,
-                "hospitality": 452.6232
+                "hospitality": 439.06611
             }
         },
         "car_pax": {
             "attraction": {
-                "Lappi": 1.30889
+                "Lappi": 1.33213
             },
             "impedance": {
-                "time": -0.00359,
-                "cost": -0.00184
+                "time": -0.00342,
+                "cost": -0.00247
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "area_leisure_buildings": 1,
-                "hospitality": 452.6232
+                "hospitality": 439.06611
             }
         }
     },
@@ -147,81 +147,81 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.403
+                "logsum": 0.59003
             },
             "individual_dummy": {}
         },
         "train": {
-            "constant": 2.26279,
+            "constant": 0.82497,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.403
+                "logsum": 0.59003
             },
             "individual_dummy": {}
         },
         "long_d_bus": {
-            "constant": 4.28431,
+            "constant": 2.55186,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.403
+                "logsum": 0.59003
             },
             "individual_dummy": {}
         },
         "car_leisure": {
-            "constant": -0.04616,
+            "constant": -0.20256,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.403
+                "logsum": 0.59003
             },
             "individual_dummy": {
-                "sh_cars1_hh1": 7.80448,
-                "sh_cars2_hh2": 7.80448,
-                "sh_cars1_hh2": 7.84577
+                "sh_cars1_hh1": 5.36956,
+                "sh_cars2_hh2": 5.36956,
+                "sh_cars1_hh2": 5.19401
             }
         },
         "car_pax": {
-            "constant": 2.73809,
+            "constant": 1.26171,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.403
+                "logsum": 0.59003
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 4.81722,
-                "sh_cars2_hh2": 4.81722
+                "sh_cars1_hh2": 3.39671,
+                "sh_cars2_hh2": 3.39671
             }
         },
         "scaling": {
             "car_leisure": {
-                "constant": 0.403,
+                "constant": 0.59003,
                 "individual_dummy": {
-                    "sh_cars1_hh1": 0.403,
-                    "sh_cars2_hh2": 0.403,
-                    "sh_cars1_hh2": 0.403
+                    "sh_cars1_hh1": 0.59003,
+                    "sh_cars2_hh2": 0.59003,
+                    "sh_cars1_hh2": 0.59003
                 }
             },
             "car_pax": {
-                "constant": 0.403,
+                "constant": 0.59003,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.403,
-                    "sh_cars2_hh2": 0.403
+                    "sh_cars1_hh2": 0.59003,
+                    "sh_cars2_hh2": 0.59003
                 }
             },
             "airplane": {
-                "constant": 0.403
+                "constant": 0.59003
             },
             "train": {
-                "constant": 0.403
+                "constant": 0.59003
             },
             "long_d_bus": {
-                "constant": 0.403
+                "constant": 0.59003
             }
         }
     },

--- a/Scripts/parameters/demand/hb_work_long.json
+++ b/Scripts/parameters/demand/hb_work_long.json
@@ -17,12 +17,6 @@
                 1.0
               ]
             },
-        "airplane": {
-            "vrk": [
-                1.0,
-                1.0
-              ]
-            },
         "train": {
             "vrk": [
                 1.0,
@@ -45,10 +39,6 @@
             100,
             9999
         ],
-        "airplane": [
-            100,
-            9999
-        ],
         "train": [
             100,
             9999
@@ -59,24 +49,11 @@
         ]
     },
     "destination_choice": {
-        "airplane": {
-            "attraction": {},
-            "impedance": {
-                "time": -0.00077,
-                "cost": -0.00952
-            },
-            "log": {
-                "attraction_size": 1
-            },
-            "attraction_size": {
-                "workplaces": 1
-            }
-        },
         "train": {
             "attraction": {},
             "impedance": {
-                "time": -0.00136,
-                "cost": -0.00952
+                "time": -0.00128,
+                "cost": -0.0237
             },
             "log": {
                 "attraction_size": 1
@@ -88,8 +65,8 @@
         "long_d_bus": {
             "attraction": {},
             "impedance": {
-                "time": -0.00138,
-                "cost": -0.00952
+                "time": -0.00209,
+                "cost": -0.0237
             },
             "log": {
                 "attraction_size": 1
@@ -101,8 +78,8 @@
         "car_work": {
             "attraction": {},
             "impedance": {
-                "time": -0.00433,
-                "cost": -0.00952
+                "time": -0.00186,
+                "cost": -0.0237
             },
             "log": {
                 "attraction_size": 1
@@ -114,7 +91,7 @@
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.00436
+                "time": -0.00399
             },
             "log": {
                 "attraction_size": 1
@@ -125,80 +102,67 @@
         }
     },
     "mode_choice": {
-        "airplane": {
+        "train": {
             "constant": 0,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.75622
-            },
-            "individual_dummy": {}
-        },
-        "train": {
-            "constant": 0.7991,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 0.75622
+                "logsum": 1.0454
             },
             "individual_dummy": {}
         },
         "long_d_bus": {
-            "constant": -0.79659,
+            "constant": -0.34248,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.75622
+                "logsum": 1.0454
             },
             "individual_dummy": {}
         },
         "car_work": {
-            "constant": -2.43923,
+            "constant": -2.94907,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.75622
+                "logsum": 1.0454
             },
             "individual_dummy": {
-                "sh_cars1_hh1": 5.53667,
-                "sh_cars2_hh2": 5.53667,
-                "sh_cars1_hh2": 4.42163
+                "sh_cars1_hh1": 4.2074,
+                "sh_cars2_hh2": 4.2074,
+                "sh_cars1_hh2": 3.58523
             }
         },
         "car_pax": {
-            "constant": -1.53338,
+            "constant": -2.72938,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.75622
+                "logsum": 1.0454
             },
             "individual_dummy": {}
         },
         "scaling": {
             "car_work": {
-                "constant": 0.75622,
+                "constant": 1.0454,
                 "individual_dummy": {
-                    "sh_cars1_hh1": 0.75622,
-                    "sh_cars2_hh2": 0.75622,
-                    "sh_cars1_hh2": 0.75622
+                    "sh_cars1_hh1": 1.0454,
+                    "sh_cars2_hh2": 1.0454,
+                    "sh_cars1_hh2": 1.0454
                 }
             },
             "car_pax": {
-                "constant": 0.75622
+                "constant": 1.0454
             },
             "train": {
-                "constant": 0.75622
+                "constant": 1.0454
             },
             "long_d_bus": {
-                "constant": 0.75622
-            },
-            "airplane": {
-                "constant": 0.75622
+                "constant": 1.0454
             }
         }
     },
@@ -210,12 +174,6 @@
               ]
         },
         "car_pax": {
-            "vrk": [
-                1.0,
-                1.0
-              ]
-        },
-        "airplane": {
             "vrk": [
                 1.0,
                 1.0

--- a/Scripts/parameters/tour_generation.py
+++ b/Scripts/parameters/tour_generation.py
@@ -146,32 +146,34 @@ tour_generation = {
         "hb_overnight": 0.0346
     },
     "hb_work_long": {
-        "population_Uusimaa": 0.00268,
-        "population_Lounais-Suomi": 0.00532,
-        "population_Ita-Suomi": 0.00449,
-        "population_Pohjois-Suomi": 0.00472
+        "age_7_17": 0.00019,
+        "age_18_29": 0.00238,
+        "age_30_49": 0.00275,
+        "age_50_64": 0.00223,
+        "age_65_99": 0.0001
     },
     "hb_business_long": {
-        "population_Uusimaa": 0.00129,
-        "population_Lounais-Suomi": 0.00334,
-        "population_Ita-Suomi": 0.00283,
-        "population_Pohjois-Suomi": 0.00185
+        "age_7_17": 0.0000,
+        "age_18_29": 0.00036,
+        "age_30_49": 0.00287,
+        "age_50_64": 0.00119,
+        "age_65_99": 0.00027
     },
     "hb_private_day": {
-        "income_0_19": 0.00339,
-        "income_20_39": 0.00502,
-        "income_40_59": 0.00708,
-        "income_60_79": 0.00744,
-        "income_80_99": 0.00892,
-        "income_100_": 0.00762
+        "income_0_19": 0.00263,
+        "income_20_39": 0.00319,
+        "income_40_59": 0.00415,
+        "income_60_79": 0.00481,
+        "income_80_99": 0.00633,
+        "income_100_": 0.0058
     },
     "hb_private_week": {
-        "income_0_19": 0.00786,
-        "income_20_39": 0.00836,
-        "income_40_59": 0.01183,
-        "income_60_79": 0.01246,
-        "income_80_99": 0.0155,
-        "income_100_": 0.01712
+        "income_0_19": 0.00632,
+        "income_20_39": 0.0069,
+        "income_40_59": 0.01044,
+        "income_60_79": 0.01059,
+        "income_80_99": 0.01404,
+        "income_100_": 0.01448
     },
     "truck": {
         "population": 0.01,

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -71,6 +71,11 @@ class ModelTest(unittest.TestCase):
         print("Adding demand and assigning")
         impedance = model.run_iteration(impedance)
 
+        # Check that model result does not change
+        self.assertAlmostEquals(
+            model.mode_share[0]["car_work"] + model.mode_share[0]["car_leisure"],
+            0.5942077838276054)
+
     def _validate_impedances(self, impedances):
         self.assertIsNotNone(impedances)
         self.assertIs(type(impedances), dict)


### PR DESCRIPTION
Generation and mode-destination choice parameters updated:
* New tour building method that matches total number of tours better to single day travel diary.
* Remove airplane from mode choice set where number of observations was less than ten (work, private day). 