### PR TITLE
Handle zone system related conflicts during storing

### DIFF
--- a/Scripts/freight_lem.py
+++ b/Scripts/freight_lem.py
@@ -79,7 +79,7 @@ def main(args):
     
     log.info("Starting end assigment")
     for ass_class in total_demand:
-        store_demand(*set_mtx_args, mode, total_demand[ass_class], 
+        store_demand(*set_mtx_args, ass_class, total_demand[ass_class], 
                      save_demand=True, omx_filename="freight_demand")
     ass_model.freight_network._assign_trucks()
     log.info("Simulation ready.")

--- a/Scripts/utils/freight_utils.py
+++ b/Scripts/utils/freight_utils.py
@@ -1,4 +1,5 @@
 import json
+import numpy
 from pathlib import Path
 from typing import Dict
 
@@ -7,6 +8,8 @@ from datatypes.purpose import FreightPurpose
 from datahandling.zonedata import FreightZoneData
 from datahandling.resultdata import ResultsData
 from parameters.commodity import commodity_conversion
+from datahandling.matrixdata import MatrixData
+from assignment.freight_assignment import FreightAssignmentPeriod
     
 
 def create_purposes(parameters_path: Path, zonedata: FreightZoneData, 
@@ -46,3 +49,64 @@ def create_purposes(parameters_path: Path, zonedata: FreightZoneData,
             log.warn(f"Aggregated commodity class '{commodity_conversion[commodity]}' "
                       f"for commodity {commodity} not found in costs json.")
     return purposes
+
+def store_demand(freight_network: FreightAssignmentPeriod, resultmatrices: MatrixData, 
+                 all_zones: numpy.ndarray, zones: numpy.ndarray, 
+                 mode: str, demand: numpy.ndarray, 
+                 save_demand: bool, omx_filename: str, key_suffix: str = ""):
+    """Handle storing demand matrices by assessing dimensions compatibility with
+    Emme network and whether demand should be saved on drive. 
+
+    Parameters
+    ----------
+    freight_network : FreightAssignmentPeriod
+        freight assignment period object
+    resultmatrices : MatrixData
+        handle for I/O matrix data handling
+    all_zones : numpy.ndarray
+        all zones in Emme network
+    zones : numpy.ndarray
+        zones within peripheral bounds of Emme network
+    mode : str
+        freight mode/assignment class
+    demand : numpy.ndarray
+        matrix that is set to Emme
+    save_demand : bool
+        if demand matrix should be saved
+    omx_filename : str
+        name of an external .omx file for saving results
+    key_suffix : str, by default empty string
+        optional name suffix for matrix e.g. purpose name
+    """
+    emme_mtx = assess_demand_dimensions(demand, all_zones.size, zones.size)
+    freight_network.set_matrix(mode, emme_mtx)
+    if save_demand:
+        with resultmatrices.open(omx_filename, freight_network.name, 
+                                 all_zones, m="a") as mtx:
+            keyname = f"{mode}_{key_suffix}" if key_suffix else mode
+            mtx[keyname] = emme_mtx
+
+def assess_demand_dimensions(demand: numpy.ndarray, nr_all_zones: int, 
+                             nr_zones: int) -> numpy.ndarray:
+    """Evaluates whether given demand matrix needs to be padded with zones 
+    to maintain zone compatibility with scenario's Emme network.
+
+    Parameters
+    ----------
+    demand : numpy.ndarray
+        type demand matrix which is assessed before setting into Emme
+    nr_all_zones : int
+        size all zones in Emme network
+    nr_zones : int
+        size of zones within peripheral bounds in Zonedata
+
+    Returns
+    -------
+    numpy.ndarray
+        demand with/without zone padding
+    """
+    fill_mtx = demand
+    if demand.size != nr_all_zones**2:
+        fill_mtx = numpy.zeros([nr_all_zones, nr_all_zones], dtype=numpy.float32)
+        fill_mtx[:nr_zones, :nr_zones] = demand
+    return fill_mtx

--- a/Scripts/utils/freight_utils.py
+++ b/Scripts/utils/freight_utils.py
@@ -53,7 +53,7 @@ def create_purposes(parameters_path: Path, zonedata: FreightZoneData,
 def store_demand(freight_network: FreightAssignmentPeriod, resultmatrices: MatrixData, 
                  all_zones: numpy.ndarray, zones: numpy.ndarray, 
                  mode: str, demand: numpy.ndarray, 
-                 save_demand: bool, omx_filename: str, key_suffix: str = ""):
+                 save_demand: bool, omx_filename: str, key_prefix: str = ""):
     """Handle storing demand matrices by assessing dimensions compatibility with
     Emme network and whether demand should be saved on drive. 
 
@@ -75,15 +75,15 @@ def store_demand(freight_network: FreightAssignmentPeriod, resultmatrices: Matri
         if demand matrix should be saved
     omx_filename : str
         name of an external .omx file for saving results
-    key_suffix : str, by default empty string
-        optional name suffix for matrix e.g. purpose name
+    key_prefix : str, by default empty string
+        optional name prefix for matrix e.g. purpose name
     """
     emme_mtx = assess_demand_dimensions(demand, all_zones.size, zones.size)
     freight_network.set_matrix(mode, emme_mtx)
     if save_demand:
         with resultmatrices.open(omx_filename, freight_network.name, 
                                  all_zones, m="a") as mtx:
-            keyname = f"{mode}_{key_suffix}" if key_suffix else mode
+            keyname = f"{key_prefix}_{mode}_" if key_prefix else mode
             mtx[keyname] = emme_mtx
 
 def assess_demand_dimensions(demand: numpy.ndarray, nr_all_zones: int, 

--- a/Scripts/utils/freight_utils.py
+++ b/Scripts/utils/freight_utils.py
@@ -83,7 +83,7 @@ def store_demand(freight_network: FreightAssignmentPeriod, resultmatrices: Matri
     if save_demand:
         with resultmatrices.open(omx_filename, freight_network.name, 
                                  all_zones, m="a") as mtx:
-            keyname = f"{key_prefix}_{mode}_" if key_prefix else mode
+            keyname = f"{key_prefix}_{mode}" if key_prefix else mode
             mtx[keyname] = emme_mtx
 
 def assess_demand_dimensions(demand: numpy.ndarray, nr_all_zones: int, 


### PR DESCRIPTION
This branch is first solution to targeting zone size conflicts between different systems (emme/utility calculation/cost calculation etc) in freight demand calc when there are external zones in koko suomi network (foreign country centroids). For passenger demand similar problems are handled elsewhere.

Storing demand is functionalised here so that it can be used for both domestic and foreign purposes in addition to assessing whether demand matrix needs padding for emme compatibility.