### PR TITLE
Systematically check all shares and calculate totals

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -284,7 +284,7 @@ def read_zonedata(path: Path,
         (Path(__file__).parent / "zone_variables.json").read_text("utf-8")
     )[data_type]
     aggs = {}
-    shares: Dict[str, Dict[str, List]] = {}
+    shares: Dict[str, Dict[str, List[str]]] = {}
     for func, cols in zone_variables.items():
         for col in cols:
             try:

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from typing import Any, List, Sequence, Union
+from typing import Any, List, Sequence, Union, Dict
 from pathlib import Path
+from collections import defaultdict
 import numpy # type: ignore
 import pandas
 import fiona
@@ -64,26 +65,10 @@ class ZoneData:
             0.5, self.zone_numbers, dtype=numpy.float32)
         self.share["share_male"] = pandas.Series(
             0.5, self.zone_numbers, dtype=numpy.float32)
-        share_7_99 = pandas.Series(0, self.zone_numbers, dtype=numpy.float32)
-        pop = data["population"]
-        wp = data["workplaces"]
-        hh = data["households"]
         for col in data:
-            if col.startswith("sh_age"):
-                pop_share = data[col]
-                self.share[col] = pop_share
-                col_name = col.replace("sh_", "")
-                self[col_name] = pop_share * pop
-                self[col_name + "_female"] = 0.5 * pop_share * pop
-                self[col_name + "_male"] = 0.5 * pop_share * pop
-                share_7_99 += pop_share
-            if col.startswith("sh_income"):
-                self[col.replace("sh_", "")] = data[col] * pop
-            if col.startswith("sh_wrk_"):
-                self[col.replace("sh_wrk_", "")] = data[col] * wp
-            if col.startswith("sh_hh"):
-                self[col.replace("sh_", "")] = data[col] * hh
-        self.share["share_age_7-99"] = share_7_99
+            if col.startswith("age"):
+                self[col + "_female"] = 0.5 * data[col]
+                self[col + "_male"] = 0.5 * data[col]
         # Convert household shares to population shares
         hh_population = (self["sh_hh1"] + 2*self["sh_hh2"] + 4.13*self["sh_hh3"])
         self.share["sh_pop_hh1"] = divide(self["sh_hh1"], hh_population)
@@ -114,6 +99,7 @@ class ZoneData:
         for dummy in ("Helsingin_kantakaupunki", "Tampereen_kantakaupunki"):
             self[dummy] = self.dummy("subarea", dummy)
         self["Lappi"] = self.dummy("county", "Lappi")
+        pop = data["population"]
         for key in ["Uusimaa", "Lounais-Suomi", "Ita-Suomi", "Pohjois-Suomi"]:
             self["population_" + key] = self.dummy("submodel", key) * pop
 
@@ -294,20 +280,23 @@ def read_zonedata(path: Path,
         data.sort_index(inplace=True)
         log.warn("File {} is not sorted in ascending order".format(path))
     zone_mapping = data[zone_mapping_name]
-    zone_variables = json.loads(
+    zone_variables: dict = json.loads(
         (Path(__file__).parent / "zone_variables.json").read_text("utf-8")
     )[data_type]
     aggs = {}
+    shares: Dict[str, Dict[str, List]] = {}
     for func, cols in zone_variables.items():
         for col in cols:
             try:
                 total = col["total"]
+                shares[total] = defaultdict(list)
             except TypeError:
                 aggs[col] = func
             else:
                 aggs[total] = func
                 for share in col["shares"]:
                     aggs[share] = lambda x: avg(x, weights=data[total])
+                    shares[total][share.split('_')[1]].append(share)
     data = data.groupby(zone_mapping_name).agg(aggs)
     data.index = data.index.astype(int)
     data.index.name = "analysis_zone_id"
@@ -327,4 +316,16 @@ def read_zonedata(path: Path,
         msg = "Zone numbers did not match for file {}".format(path)
         log.error(msg)
         raise IndexError(msg)
+    for total in shares:
+        for share_type, type_shares in shares[total].items():
+            for share in type_shares:
+                data[share.replace("sh_", "")] = data[share] * data[total]
+            if len(type_shares[0].split('_')) == 4:
+                # Example: Sum sh_age_7_17 .. sh_age_65_99 in sh_age_7_99
+                total_interval = "sh_{}_{}_{}".format(
+                    share_type, type_shares[0].split('_')[2],
+                    type_shares[-1].split('_')[3])
+            else:
+                total_interval = f"sh_{share_type}_all"
+            data[total_interval] = data[type_shares].sum(axis="columns")
     return data, zone_mapping

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -65,10 +65,6 @@ class ZoneData:
             0.5, self.zone_numbers, dtype=numpy.float32)
         self.share["share_male"] = pandas.Series(
             0.5, self.zone_numbers, dtype=numpy.float32)
-        for col in data:
-            if col.startswith("age"):
-                self[col + "_female"] = 0.5 * data[col]
-                self[col + "_male"] = 0.5 * data[col]
         # Convert household shares to population shares
         hh_population = (self["sh_hh1"] + 2*self["sh_hh2"] + 4.13*self["sh_hh3"])
         self.share["sh_pop_hh1"] = divide(self["sh_hh1"], hh_population)

--- a/Scripts/models/car_use.py
+++ b/Scripts/models/car_use.py
@@ -150,7 +150,7 @@ class CarUseModel(LogitModel):
             # Comparison data has car user shares of population
             # over 6 years old (from HEHA)
             population_7_99 = (self.zone_data["population"][self.bounds]
-                               * self.zone_data["share_age_7-99"][self.bounds])
+                               * self.zone_data["sh_age_7_99"][self.bounds])
         # print car use share by municipality and area
         for area_type in self.zone_data.aggregations.mappings:
             prob_area = self.zone_data.aggregations.averages(

--- a/Scripts/parameters/demand/hb_edu_student.json
+++ b/Scripts/parameters/demand/hb_edu_student.json
@@ -100,8 +100,8 @@
                 "transform": -0.28318
             },
             "attraction_size": {
-                "edu_higher": 1,
-                "edu_other": 0.42017
+                "wrk_edu_higher": 1,
+                "wrk_edu_other": 0.42017
             },
             "transform": {
                 "attraction": {
@@ -125,8 +125,8 @@
                 "cost": -0.28318
             },
             "attraction_size": {
-                "edu_higher": 1,
-                "edu_other": 0.42017
+                "wrk_edu_higher": 1,
+                "wrk_edu_other": 0.42017
             }
         },
         "transit_work": {
@@ -142,8 +142,8 @@
                 "cost": -0.28318
             },
             "attraction_size": {
-                "edu_higher": 1,
-                "edu_other": 0.42017
+                "wrk_edu_higher": 1,
+                "wrk_edu_other": 0.42017
             }
         },
         "bike": {
@@ -157,8 +157,8 @@
                 "attraction_size": 1.0
             },
             "attraction_size": {
-                "edu_higher": 1,
-                "edu_other": 0.42017
+                "wrk_edu_higher": 1,
+                "wrk_edu_other": 0.42017
             }
         },
         "walk": {
@@ -172,8 +172,8 @@
                 "attraction_size": 1.0
             },
             "attraction_size": {
-                "edu_higher": 1,
-                "edu_other": 0.42017
+                "wrk_edu_higher": 1,
+                "wrk_edu_other": 0.42017
             }
         }
     },

--- a/Scripts/parameters/demand/hb_grocery.json
+++ b/Scripts/parameters/demand/hb_grocery.json
@@ -1,7 +1,7 @@
 {
     "name": "hb_grocery",
     "orig": "home",
-    "dest": "shop",
+    "dest": "wrk_shop",
     "area": "all",
     "struct": "mode>dest",
     "impedance_share": {
@@ -100,7 +100,7 @@
                 "transform": -0.54117
             },
             "attraction_size": {
-                "shop": 207.44163,
+                "wrk_shop": 207.44163,
                 "population": 1
             },
             "transform": {
@@ -125,7 +125,7 @@
                 "cost": -0.54117
             },
             "attraction_size": {
-                "shop": 207.44163,
+                "wrk_shop": 207.44163,
                 "population": 1
             }
         },
@@ -141,7 +141,7 @@
                 "cost": -0.54117
             },
             "attraction_size": {
-                "shop": 207.44163,
+                "wrk_shop": 207.44163,
                 "population": 1
             }
         },
@@ -156,7 +156,7 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 207.44163,
+                "wrk_shop": 207.44163,
                 "population": 1
             }
         },
@@ -171,7 +171,7 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 207.44163,
+                "wrk_shop": 207.44163,
                 "population": 1
             }
         }

--- a/Scripts/parameters/demand/hb_leisure.json
+++ b/Scripts/parameters/demand/hb_leisure.json
@@ -100,8 +100,8 @@
                 "transform": -0.59043
             },
             "attraction_size": {
-                "hospitality": 1,
-                "recreation": 1.49347
+                "wrk_hospitality": 1,
+                "wrk_recreation": 1.49347
             },
             "transform": {
                 "attraction": {
@@ -125,8 +125,8 @@
                 "cost": -0.59043
             },
             "attraction_size": {
-                "hospitality": 1,
-                "recreation": 1.49347
+                "wrk_hospitality": 1,
+                "wrk_recreation": 1.49347
             }
         },
         "transit_leisure": {
@@ -144,8 +144,8 @@
                 "cost": -0.59043
             },
             "attraction_size": {
-                "hospitality": 1,
-                "recreation": 1.49347
+                "wrk_hospitality": 1,
+                "wrk_recreation": 1.49347
             }
         },
         "bike": {
@@ -159,8 +159,8 @@
                 "attraction_size": 1.0
             },
             "attraction_size": {
-                "hospitality": 1,
-                "recreation": 1.49347
+                "wrk_hospitality": 1,
+                "wrk_recreation": 1.49347
             }
         },
         "walk": {
@@ -174,8 +174,8 @@
                 "attraction_size": 1.0
             },
             "attraction_size": {
-                "hospitality": 1,
-                "recreation": 1.49347
+                "wrk_hospitality": 1,
+                "wrk_recreation": 1.49347
             }
         }
     },

--- a/Scripts/parameters/demand/hb_other_shop.json
+++ b/Scripts/parameters/demand/hb_other_shop.json
@@ -1,7 +1,7 @@
 {
     "name": "hb_other_shop",
     "orig": "home",
-    "dest": "shop",
+    "dest": "wrk_shop",
     "area": "all",
     "struct": "mode>dest",
     "impedance_share": {
@@ -100,8 +100,8 @@
                 "transform": -0.42901
             },
             "attraction_size": {
-                "shop": 1,
-                "healthcare": 0.14018
+                "wrk_shop": 1,
+                "wrk_healthcare": 0.14018
             },
             "transform": {
                 "attraction": {
@@ -125,8 +125,8 @@
                 "cost": -0.42901
             },
             "attraction_size": {
-                "shop": 1,
-                "healthcare": 0.14018
+                "wrk_shop": 1,
+                "wrk_healthcare": 0.14018
             }
         },
         "transit_leisure": {
@@ -144,8 +144,8 @@
                 "cost": -0.42901
             },
             "attraction_size": {
-                "shop": 1,
-                "healthcare": 0.14018
+                "wrk_shop": 1,
+                "wrk_healthcare": 0.14018
             }
         },
         "bike": {
@@ -159,8 +159,8 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "healthcare": 0.14018
+                "wrk_shop": 1,
+                "wrk_healthcare": 0.14018
             }
         },
         "walk": {
@@ -174,8 +174,8 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "healthcare": 0.14018
+                "wrk_shop": 1,
+                "wrk_healthcare": 0.14018
             }
         }
     },

--- a/Scripts/parameters/demand/hb_private_day.json
+++ b/Scripts/parameters/demand/hb_private_day.json
@@ -60,7 +60,7 @@
             },
             "attraction_size": {
                 "population": 1,
-                "recreation": 35.74856
+                "wrk_recreation": 35.74856
             }
         },
         "long_d_bus": {
@@ -74,7 +74,7 @@
             },
             "attraction_size": {
                 "population": 1,
-                "recreation": 35.74856
+                "wrk_recreation": 35.74856
             }
         },
         "car_leisure": {
@@ -88,7 +88,7 @@
             },
             "attraction_size": {
                 "population": 1,
-                "recreation": 35.74856
+                "wrk_recreation": 35.74856
             }
         },
         "car_pax": {
@@ -102,7 +102,7 @@
             },
             "attraction_size": {
                 "population": 1,
-                "recreation": 35.74856
+                "wrk_recreation": 35.74856
             }
         }
     },

--- a/Scripts/parameters/demand/hb_private_week.json
+++ b/Scripts/parameters/demand/hb_private_week.json
@@ -72,7 +72,7 @@
             },
             "attraction_size": {
                 "area_leisure_buildings": 1,
-                "hospitality": 439.06611
+                "wrk_hospitality": 439.06611
             }
         },
         "train": {
@@ -88,7 +88,7 @@
             },
             "attraction_size": {
                 "area_leisure_buildings": 1,
-                "hospitality": 439.06611
+                "wrk_hospitality": 439.06611
             }
         },
         "long_d_bus": {
@@ -104,7 +104,7 @@
             },
             "attraction_size": {
                 "area_leisure_buildings": 1,
-                "hospitality": 439.06611
+                "wrk_hospitality": 439.06611
             }
         },
         "car_leisure": {
@@ -120,7 +120,7 @@
             },
             "attraction_size": {
                 "area_leisure_buildings": 1,
-                "hospitality": 439.06611
+                "wrk_hospitality": 439.06611
             }
         },
         "car_pax": {
@@ -136,7 +136,7 @@
             },
             "attraction_size": {
                 "area_leisure_buildings": 1,
-                "hospitality": 439.06611
+                "wrk_hospitality": 439.06611
             }
         }
     },

--- a/Scripts/parameters/demand/ob_other.json
+++ b/Scripts/parameters/demand/ob_other.json
@@ -104,9 +104,9 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "recreation": 1.52419,
-                "hospitality": 1.69511
+                "wrk_shop": 1,
+                "wrk_recreation": 1.52419,
+                "wrk_hospitality": 1.69511
             }
         },
         "car_pax": {
@@ -120,9 +120,9 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "recreation": 1.52419,
-                "hospitality": 1.69511
+                "wrk_shop": 1,
+                "wrk_recreation": 1.52419,
+                "wrk_hospitality": 1.69511
             }
         },
         "transit_leisure": {
@@ -136,9 +136,9 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "recreation": 1.52419,
-                "hospitality": 1.69511
+                "wrk_shop": 1,
+                "wrk_recreation": 1.52419,
+                "wrk_hospitality": 1.69511
             }
         },
         "bike": {
@@ -152,9 +152,9 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "recreation": 1.52419,
-                "hospitality": 1.69511
+                "wrk_shop": 1,
+                "wrk_recreation": 1.52419,
+                "wrk_hospitality": 1.69511
             }
         },
         "walk": {
@@ -168,9 +168,9 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "recreation": 1.52419,
-                "hospitality": 1.69511
+                "wrk_shop": 1,
+                "wrk_recreation": 1.52419,
+                "wrk_hospitality": 1.69511
             }
         }
     },

--- a/Scripts/parameters/demand/wb_other.json
+++ b/Scripts/parameters/demand/wb_other.json
@@ -104,9 +104,9 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "recreation": 0.96002,
-                "hospitality": 1.79691
+                "wrk_shop": 1,
+                "wrk_recreation": 0.96002,
+                "wrk_hospitality": 1.79691
             }
         },
         "car_pax": {
@@ -120,9 +120,9 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "recreation": 0.96002,
-                "hospitality": 1.79691
+                "wrk_shop": 1,
+                "wrk_recreation": 0.96002,
+                "wrk_hospitality": 1.79691
             }
         },
         "transit_leisure": {
@@ -136,9 +136,9 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "recreation": 0.96002,
-                "hospitality": 1.79691
+                "wrk_shop": 1,
+                "wrk_recreation": 0.96002,
+                "wrk_hospitality": 1.79691
             }
         },
         "bike": {
@@ -152,9 +152,9 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "recreation": 0.96002,
-                "hospitality": 1.79691
+                "wrk_shop": 1,
+                "wrk_recreation": 0.96002,
+                "wrk_hospitality": 1.79691
             }
         },
         "walk": {
@@ -168,9 +168,9 @@
                 "attraction_size": 1
             },
             "attraction_size": {
-                "shop": 1,
-                "recreation": 0.96002,
-                "hospitality": 1.79691
+                "wrk_shop": 1,
+                "wrk_recreation": 0.96002,
+                "wrk_hospitality": 1.79691
             }
         }
     },


### PR DESCRIPTION
Replace the hard-coded population/workplace/household segment calculation with a general calculation of `"sh_type_x" * "total"`. Systematically check that no shares sum to more than one.