### PR TITLE
Dynamically delete strategy files, except in long-dist assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ Scripts/.pytest_cache
 Scripts/tests/.pytest_cache
 Scripts/.env
 Scripts/tests/test_data/Results/*
+!Scripts/tests/test_data/Results/STRATS_s19/config
 !Scripts/tests/test_data/Results/test/Matrices/uusimaa/cost*
 !Scripts/tests/test_data/Results/test/Matrices/uusimaa/dist*
 !Scripts/tests/test_data/Results/test/Matrices/uusimaa/time*

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -42,6 +42,8 @@ class EmmeAssignmentModel(AssignmentModel):
     delete_extra_matrices : bool (optional)
         If True, only matrices needed for demand calculation will be
         returned from end assignment.
+    delete_strat_files : bool (optional)
+            If True, strategy files will be deleted immediately after usage.
     time_periods : dict (optional)
         key : str
             Time period names, default is aht, pt, iht
@@ -59,6 +61,7 @@ class EmmeAssignmentModel(AssignmentModel):
                  save_matrices: bool = False,
                  use_free_flow_speeds: bool = False,
                  delete_extra_matrices: bool = False,
+                 delete_strat_files: bool = False,
                  time_periods: dict[str, str] = param.time_periods,
                  first_matrix_id: int = 100):
         self.separate_emme_scenarios = separate_emme_scenarios
@@ -67,6 +70,7 @@ class EmmeAssignmentModel(AssignmentModel):
         self.transit_classes = (param.long_distance_transit_classes
             if self.use_free_flow_speeds else param.transit_classes)
         self.delete_extra_matrices = delete_extra_matrices
+        self._delete_strat_files = delete_strat_files
         self.time_periods = time_periods
         EmmeMatrix.id_counter = first_matrix_id if save_matrices else 0
         self.emme_project = emme_context
@@ -119,7 +123,8 @@ class EmmeAssignmentModel(AssignmentModel):
                 tp, scen_id, self.emme_project,
                 separate_emme_scenarios=self.separate_emme_scenarios,
                 use_stored_speeds=(car_time_files is not None),
-                delete_extra_matrices=self.delete_extra_matrices))
+                delete_extra_matrices=self.delete_extra_matrices,
+                delete_strat_files=self._delete_strat_files))
         ass_classes = param.transport_classes + ("bus",)
         self._create_attributes(
             self.day_scenario, ass_classes, self._extra, self._netfield)

--- a/Scripts/assignment/emme_bindings/mock_project.py
+++ b/Scripts/assignment/emme_bindings/mock_project.py
@@ -4,6 +4,7 @@ import numpy # type: ignore
 from collections import namedtuple
 import copy
 import os
+from pathlib import Path
 
 
 MODE_TYPES = {
@@ -478,6 +479,8 @@ Modeller = namedtuple("Modeller", "emmebank")
 
 class EmmeBank:
     def __init__(self):
+        self.path = (Path(__file__).parent.parent.parent
+                     / "tests" / "test_data" / "Results" / "test")
         self._scenarios = {}
         self._matrices = {}
         self._functions = {}

--- a/Scripts/assignment/long_dist_period.py
+++ b/Scripts/assignment/long_dist_period.py
@@ -77,8 +77,7 @@ class WholeDayPeriod(AssignmentPeriod):
                 Assignment class (car_work/transit/...) : numpy 2-d matrix
         """
         self._assign_cars(self.stopping_criteria["coarse"])
-        self._assign_transit(
-            param.long_distance_transit_classes, keep_strat_files=True)
+        self._assign_transit(param.long_distance_transit_classes)
         self._long_distance_trips_assigned = True
         mtxs = self._get_impedances(modes)
         for ass_cl in param.car_classes:
@@ -99,9 +98,11 @@ class WholeDayPeriod(AssignmentPeriod):
         """
         self._assign_cars(self.stopping_criteria["fine"])
         if not self._long_distance_trips_assigned:
-            self._assign_transit(
-                param.long_distance_transit_classes, keep_strat_files=True)
+            self._assign_transit(param.long_distance_transit_classes)
+        strategy_paths = self._strategy_paths
         for transit_class in param.long_distance_transit_classes:
             self._calc_transit_network_results(transit_class)
+            if self._delete_strat_files:
+                strategy_paths[transit_class].unlink(missing_ok=True)
         self._calc_transit_link_results()
         return self._get_impedances(self.transport_classes)

--- a/Scripts/assignment/long_dist_period.py
+++ b/Scripts/assignment/long_dist_period.py
@@ -18,6 +18,7 @@ class WholeDayPeriod(AssignmentPeriod):
     """
     def __init__(self, *args, **kwargs):
         AssignmentPeriod.__init__(self, *args, **kwargs)
+        self._long_distance_trips_assigned = False
         for criteria in self.stopping_criteria.values():
                 criteria["max_iterations"] = 0
         self.transport_classes = (param.car_classes
@@ -76,7 +77,8 @@ class WholeDayPeriod(AssignmentPeriod):
                 Assignment class (car_work/transit/...) : numpy 2-d matrix
         """
         self._assign_cars(self.stopping_criteria["coarse"])
-        self._assign_transit(param.long_distance_transit_classes)
+        self._assign_transit(
+            param.long_distance_transit_classes, keep_strat_files=True)
         self._long_distance_trips_assigned = True
         mtxs = self._get_impedances(modes)
         for ass_cl in param.car_classes:
@@ -97,7 +99,9 @@ class WholeDayPeriod(AssignmentPeriod):
         """
         self._assign_cars(self.stopping_criteria["fine"])
         if not self._long_distance_trips_assigned:
-            self._assign_transit(param.long_distance_transit_classes)
-        self._calc_transit_network_results(
-            param.long_distance_transit_classes)
+            self._assign_transit(
+                param.long_distance_transit_classes, keep_strat_files=True)
+        for transit_class in param.long_distance_transit_classes:
+            self._calc_transit_network_results(transit_class)
+        self._calc_transit_link_results()
         return self._get_impedances(self.transport_classes)

--- a/Scripts/assignment/mock_assignment.py
+++ b/Scripts/assignment/mock_assignment.py
@@ -17,7 +17,8 @@ class MockAssignmentModel(AssignmentModel):
     def __init__(self, matrices: MatrixData,
                  use_free_flow_speeds: bool = False,
                  time_periods: Dict[str, str]=param.time_periods,
-                 delete_extra_matrices: bool = False):
+                 delete_extra_matrices: bool = False,
+                 delete_strat_files: bool = False):
         self.matrices = matrices
         log.info("Reading matrices from " + str(self.matrices.path))
         self.use_free_flow_speeds = use_free_flow_speeds

--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -155,8 +155,8 @@ class TransitAssignmentPeriod(OffPeakPeriod):
             Type (time/cost/dist) : dict
                 Assignment class (transit_work/...) : numpy 2-d matrix
         """
-        self._assign_transit(param.transit_classes)
-        self._calc_transit_network_results()
+        self._assign_transit(param.transit_classes, calc_network_results=True)
+        self._calc_transit_link_results()
         mtxs = self._get_impedances(self._end_assignment_classes)
         for tc in self.assignment_modes:
             self.assignment_modes[tc].release_matrices()

--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -59,7 +59,9 @@ class OffPeakPeriod(AssignmentPeriod):
             param.stopping_criteria["coarse"])
         stopping_criteria["max_iterations"] = 0
         self._assign_cars(stopping_criteria)
-        self._assign_transit(param.local_transit_classes)
+        self._assign_transit(
+            param.local_transit_classes,
+            delete_strat_files=self._delete_strat_files)
         return []
 
     def get_soft_mode_impedances(self):
@@ -155,7 +157,9 @@ class TransitAssignmentPeriod(OffPeakPeriod):
             Type (time/cost/dist) : dict
                 Assignment class (transit_work/...) : numpy 2-d matrix
         """
-        self._assign_transit(param.transit_classes, calc_network_results=True)
+        self._assign_transit(
+            param.transit_classes, calc_network_results=True,
+            delete_strat_files=self._delete_strat_files)
         self._calc_transit_link_results()
         mtxs = self._get_impedances(self._end_assignment_classes)
         for tc in self.assignment_modes:

--- a/Scripts/lem.py
+++ b/Scripts/lem.py
@@ -67,6 +67,7 @@ def main(args):
     kwargs = {
         "use_free_flow_speeds": calculate_long_dist_demand,
         "delete_extra_matrices": args.delete_extra_matrices,
+        "delete_strat_files": args.del_strat_files,
     }
     if calculate_long_dist_demand:
         kwargs["time_periods"] = {"vrk": "WholeDayPeriod"}

--- a/Scripts/tests/test_data/Results/STRATS_s19/config
+++ b/Scripts/tests/test_data/Results/STRATS_s19/config
@@ -1,0 +1,24 @@
+{
+    "strat_files": [
+        {
+            "name": "transit_work",
+            "path": "STRAT_0"
+        },
+        {
+            "name": "transit_leisure",
+            "path": "STRAT_1"
+        },
+		{
+            "name": "train",
+            "path": "STRAT_2"
+        },
+        {
+            "name": "long_d_bus",
+            "path": "STRAT_3"
+        },
+        {
+            "name": "airplane",
+            "path": "STRAT_4"
+        }
+    ]
+}


### PR DESCRIPTION
This saves something like 20 Gb maximum temporal disk space when running the short-tour model for whole Finland. In long-distance model, keeping the strategy files is much more useful (and takes up less disk space), so I kept them there.