### PR TITLE
Do not store link auto time in stored-speed assignment

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -591,10 +591,12 @@ class AssignmentPeriod(Period):
             if assign_report["stopping_criterion"] == "MAX_ITERATIONS":
                 log.warn("Car assignment not fully converged.")
         network = self.emme_scenario.get_network()
-        time_attr = self.netfield("car_time")
+        if not self.use_stored_speeds:
+            time_attr = self.netfield("car_time")
+            for link in network.links():
+                link[time_attr] = link.auto_time
         truck_time_attr = self.extra("truck_time")
         for link in network.links():
-            link[time_attr] = link.auto_time
             # Truck speed limited to 90 km/h
             link[truck_time_attr] = max(link.auto_time, link.length * 0.67)
         self.emme_scenario.publish_network(network)

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -242,8 +242,9 @@ class EmmeAssignmentModel(AssignmentModel):
         car_times = pandas.DataFrame(
             {ap.netfield("car_time"): ap.get_car_times()
                 for ap in self.assignment_periods})
-        car_times.index.names = ("i_node", "j_node")
-        resultdata.print_data(car_times, "netfield_links.txt")
+        if not car_times.empty:
+            car_times.index.names = ("i_node", "j_node")
+            resultdata.print_data(car_times, "netfield_links.txt")
 
         # Aggregate results to 24h
         for ap in self.assignment_periods:
@@ -578,8 +579,11 @@ class EmmeAssignmentModel(AssignmentModel):
                 speed = (60 * 2 * link.length
                          / (link[car_time_attr]+rlink[car_time_attr]))
             else:
-                speed = (0.3*(60*link.length/link[car_time_attr])
-                         + 0.7*link.data2)
+                try:
+                    speed = (0.3*(60*link.length/link[car_time_attr])
+                             + 0.7*link.data2)
+                except ZeroDivisionError:
+                    speed = link.data2
             speed = max(speed, 50.0)
 
             # Calculate start noise


### PR DESCRIPTION
To retain warnings about missing stored link travel times when doing several stored-speed assignments on the same network, auto time should not be stored after stored-speed assignment.