### PR TITLE
Weight congested car time (time - free_flow_time) by 1.5

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -354,6 +354,8 @@ class AssignmentPeriod(Period):
                         link.volume_delay_func = roadclass.volume_delay_func
                 link.data1 = roadclass.lane_capacity
                 link.data2 = roadclass.free_flow_speed
+                link[param.free_flow_time_attr] = (60 * link.length
+                                                   / roadclass.free_flow_speed)
             elif linktype in param.custom_roadtypes:
                 # Custom car link
                 if link.volume_delay_func != 90:
@@ -361,6 +363,8 @@ class AssignmentPeriod(Period):
                         link.volume_delay_func = 91
                     else:
                         link.volume_delay_func = linktype - 90
+                link[param.free_flow_time_attr] = (60 * link.length
+                                                   / link.data2)
                 for linktype in param.roadclasses:
                     roadclass = param.roadclasses[linktype]
                     if (link.volume_delay_func == roadclass.volume_delay_func

--- a/Scripts/assignment/emme_assignment.py
+++ b/Scripts/assignment/emme_assignment.py
@@ -98,6 +98,9 @@ class EmmeAssignmentModel(AssignmentModel):
                     path / "netfield_links.txt", field_separator="TAB",
                     revert_on_error=False, scenario=self.mod_scenario)
         self._add_bus_stops()
+        self.emme_project.create_extra_attribute(
+            "LINK", param.free_flow_time_attr, "free-flow car time",
+            overwrite=True, scenario=self.mod_scenario)
         if self.separate_emme_scenarios:
             self.day_scenario = self.emme_project.copy_scenario(
                 self.mod_scenario, self.mod_scenario.number + 1,
@@ -154,6 +157,9 @@ class EmmeAssignmentModel(AssignmentModel):
         self.freight_network = FreightAssignmentPeriod(
             "vrk", self.mod_scenario.number, self.emme_project)
         self.assignment_periods = [self.freight_network]
+        self.emme_project.create_extra_attribute(
+            "LINK", param.free_flow_time_attr, "free-flow car time",
+            overwrite=True, scenario=self.mod_scenario)
         self.emme_project.create_extra_attribute(
             "TRANSIT_LINE", param.terminal_cost_attr, "terminal cost",
             overwrite=True, scenario=self.mod_scenario)

--- a/Scripts/create_emme_project.py
+++ b/Scripts/create_emme_project.py
@@ -55,7 +55,7 @@ def create_emme_project(args):
     nr_attr = {
         "centroids": nr_transit_classes * (nr_segment_results-1),
         "regular_nodes": nr_transit_classes * (nr_segment_results-1),
-        "links": nr_veh_classes + 3,
+        "links": nr_veh_classes + 4,
         "transit_lines": nr_transit_classes + 2,
         "transit_segments": nr_transit_classes*nr_segment_results + 2,
     }

--- a/Scripts/lem_validate_inputfiles.py
+++ b/Scripts/lem_validate_inputfiles.py
@@ -142,7 +142,7 @@ def main(args):
             nr_assignment_modes = len(param.assignment_modes)
             nr_new_attr = {
                 "nodes": nr_transit_classes * (nr_segment_results-1),
-                "links": nr_veh_classes + 3,
+                "links": nr_veh_classes + 4,
                 "transit_lines": nr_transit_classes + 2,
                 "transit_segments": nr_transit_classes*nr_segment_results + 2,
             }

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -590,6 +590,7 @@ municipality_attr = "#municipality"
 terminal_cost_attr = "@freight_term_cost"
 freight_gate_attr = "@freight_gate"
 ferry_wait_attr = "@ferry_wait_time"
+free_flow_time_attr = "@free_flow_time_attr"
 extra_freight_cost_attr = "#extra_cost"
 railtypes = {
     2: "tram",


### PR DESCRIPTION
In this solution, route choices are not affected by the extra weight on congested time (as that would require us to change the volume-delay functions, affecting actual link speeds). However, the time variable, which is fed to the demand model, is directly modified. This means that the current solution also affects cost-benefit analyses. This is perfectly in line with [ASEK 8.0](https://bransch.trafikverket.se/contentassets/0e5777a6301e4134a6e8365fc20c0e0e/asek-8.0-2-april-2024.pdf), but not with the current version of [Hankearvioinnin yksikköarvot](https://aineistot.vayla.fi/ava/Julkaisut/Vaylavirasto/vo_2024-44v2_hankearvioinnin_yksikkoarvot_2022_web.pdf). Maybe we should try to make it part of the next version?