### PR TITLE
Enable several databases in same EMME project, choose according to submodel

### DIFF
--- a/Scripts/assignment/emme_bindings/emme_project.py
+++ b/Scripts/assignment/emme_bindings/emme_project.py
@@ -20,17 +20,11 @@ class EmmeProject:
     ----------
     project_path : str
         Path to EMME project (.emp) file
-    emmebank_path : str (optional)
-        Path to emmebank file (if EMME project is not initialized)
-    project_name : str (optional)
-        For naming project
     visible : bool (optional)
         Whether an EMME GUI window should be opened
     """
     def __init__(self,
                  project_path: str,
-                 emmebank_path: Optional[str] = None,
-                 project_name: Optional[str] = None,
                  visible: Optional[bool] = False):
         log.info("Starting Emme...")
         if TYPE_CHECKING: self.cm: Optional[ContentManager] = None #type checker hint
@@ -38,20 +32,56 @@ class EmmeProject:
             "project": project_path,
             "visible": visible,
             "user_initials": "TC"}
-        emme_desktop = (_app.start(**kwargs) if visible
+        self.emme_desktop = (_app.start(**kwargs) if visible
             else _app.start_dedicated(**kwargs))
-        if emmebank_path is not None:
-            db = emme_desktop.data_explorer().add_database(emmebank_path)
-            db.open()
-            emme_desktop.project.save()
-        if project_name is not None:
-            emme_desktop.project.name = project_name
-            emme_desktop.project.save()
+
+    def add_db(self, emmebank_path: str, project_name: str):
+        """Add emmebank file to project.
+
+        Parameters
+        ----------
+        emmebank_path : str
+            Path to emmebank file
+        project_name : str
+            For naming project
+        """
+        db = self.emme_desktop.data_explorer().add_database(emmebank_path)
+        db.open()
+        self.emme_desktop.project.name = project_name
+        self.emme_desktop.project.save()
+
+    def try_open_db(self, db_name: str):
+        """Try to open database.
+
+        If EMME project contains more than one database, open the one
+        with name db_name. If no matching name is found, try to find a
+        database called "alueelliset_osamallit". If project contains
+        only one database or no matching name is found, do nothing.
+
+        Parameters
+        ----------
+        db_name : str
+            Name of database to try to open
+        """
+        if len(self.emme_desktop.data_explorer().databases()) > 1:
+            if not self._open_db(db_name):
+                self._open_db("alueelliset_osamallit")
+
+    def _open_db(self, db_name: str) -> bool:
+        for db in self.emme_desktop.data_explorer().databases():
+            if db.title() == db_name:
+                db.open()
+                self.emme_desktop.project.save()
+                log.info(f"Database {db_name} opened")
+                return True
+        else:
+            return False
+
+    def start(self):
         # Add logging to EMME
         sh = logging.StreamHandler(stream=self)
         logging.getLogger().addHandler(sh)
-
-        self.modeller = _m.Modeller(emme_desktop)
+        self.modeller = _m.Modeller(self.emme_desktop)
         log.info("Emme started")
         self.import_scenario = self.modeller.tool(
             "inro.emme.data.scenario.import_scenario")

--- a/Scripts/create_emme_project.py
+++ b/Scripts/create_emme_project.py
@@ -11,9 +11,10 @@ import parameters.assignment as param
 def create_emme_project(args):
     project_dir = args.emme_path
     project_name = args.project_name
-    db_dir = Path(project_dir, project_name, "Database")
-    project_path = _app.create_project(project_dir, project_name)
-    db_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        project_path = _app.create_project(project_dir, project_name)
+    except FileExistsError:
+            project_path = Path(project_dir, project_name, project_name + ".emp")
     default_dimensions = {
         "scalar_matrices": 100,
         "origin_matrices": 100,
@@ -72,14 +73,17 @@ def create_emme_project(args):
 
     dim.update(default_dimensions)
     scenario_num = args.first_scenario_id
+    db_dir = Path(project_dir, project_name, args.submodel)
+    db_dir.mkdir(parents=True, exist_ok=True)
     eb = _eb.create(db_dir / "emmebank", dim)
     eb.text_encoding = 'utf-8'
-    eb.title = project_name
+    eb.title = args.submodel
     eb.coord_unit_length = 0.001
     eb.create_scenario(scenario_num)
     emmebank_path = eb.path
     eb.dispose()
-    EmmeProject(project_path, emmebank_path, project_name, visible=True)
+    ep = EmmeProject(project_path, visible=True)
+    ep.add_db(emmebank_path, project_name)
 
 if __name__ == "__main__":
     # Initially read defaults from config file ("dev-config.json")

--- a/Scripts/freight_lem.py
+++ b/Scripts/freight_lem.py
@@ -27,7 +27,10 @@ def main(args):
     emme_project_path = Path(args.emme_path)
     parameters_path = Path(__file__).parent / "parameters" / "freight"
     save_matrices = True if args.specify_commodity_names else False
-    ass_model = EmmeAssignmentModel(EmmeProject(emme_project_path),
+    ep = EmmeProject(emme_project_path)
+    ep.try_open_db("koko_suomi")
+    ep.start()
+    ass_model = EmmeAssignmentModel(ep,
                                     first_scenario_id=args.first_scenario_id,
                                     save_matrices=save_matrices,
                                     first_matrix_id=args.first_matrix_id)

--- a/Scripts/lem.py
+++ b/Scripts/lem.py
@@ -85,9 +85,11 @@ def main(args):
                     emme_project_path))
         log.info("Initializing Emme...")
         from assignment.emme_bindings.emme_project import EmmeProject
+        ep = EmmeProject(emme_project_path)
+        ep.try_open_db(args.submodel)
+        ep.start()
         ass_model = EmmeAssignmentModel(
-            EmmeProject(emme_project_path),
-            first_scenario_id=args.first_scenario_id,
+            ep, first_scenario_id=args.first_scenario_id,
             separate_emme_scenarios=args.separate_emme_scenarios,
             save_matrices=args.save_matrices,
             first_matrix_id=args.first_matrix_id, **kwargs)

--- a/Scripts/lem_validate_inputfiles.py
+++ b/Scripts/lem_validate_inputfiles.py
@@ -102,7 +102,22 @@ def main(args):
             import inro.emme.desktop.app as _app # type: ignore
             app = _app.start_dedicated(
                 project=emp_path, visible=False, user_initials="HSL")
-            emmebank = app.data_explorer().active_database().core_emmebank
+            data_expl = app.data_explorer()
+            databases = data_expl.databases()
+            if len(databases) > 1:
+                for db in databases:
+                    if db.title() == args.submodel[i]:
+                        emmebank = db.core_emmebank
+                        break
+                else:
+                    for db in databases:
+                        if db.title() == "alueelliset_osamallit":
+                            emmebank = db.core_emmebank
+                            break
+                    else:
+                        emmebank = data_expl.active_database().core_emmebank
+            else:
+                emmebank = data_expl.active_database().core_emmebank
             scen = emmebank.scenario(first_scenario_ids[i])
             zone_numbers[args.submodel[i]] = scen.zone_numbers
             if scen is None:

--- a/Scripts/tests/emme_only/test_assignment.py
+++ b/Scripts/tests/emme_only/test_assignment.py
@@ -41,6 +41,7 @@ class EmmeAssignmentTest:
             db_dir.mkdir(parents=True, exist_ok=True)
         except FileExistsError:
             project_path = project_dir / project_name / (project_name + ".emp")
+        emme_context = EmmeProject(project_path)
         dim = {
             "scalar_matrices": 100,
             "origin_matrices": 100,
@@ -62,12 +63,14 @@ class EmmeAssignmentTest:
         scenario_num = 19
         try:
             eb = _eb.create(db_dir / "emmebank", dim)
+        except RuntimeError:
+            pass
+        else:
             eb.create_scenario(scenario_num)
             emmebank_path = eb.path
             eb.dispose()
-        except RuntimeError:
-            emmebank_path = None
-        emme_context = EmmeProject(project_path, emmebank_path, "test")
+            emme_context.add_db(emmebank_path, "test")
+        emme_context.start()
         emme_context.import_scenario(
             project_dir.parent / "Network", scenario_num, "test",
             overwrite=True)


### PR DESCRIPTION
- Refactor `EmmeProject`
- Enable creating several different-sized databases in same EMME project
- Try to find a database with same name as submodel in model run