### PR TITLE
Output aggregate mode shares only for proper submodel area

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -192,6 +192,17 @@ class ZoneData:
         else:  # Return matrix (purpose zones -> all zones)
             return val[bounds, :]
 
+    @property
+    def is_in_submodel(self) -> pandas.Series:
+        """Boolean mapping of zones, whether in proper sub-model area."""
+        mapping = self.aggregations.mappings["submodel"]
+        submodels = mapping.drop_duplicates()
+        for submodel in submodels:
+            if self.mapping.name == submodel.lower().replace('-', '_'):
+                return mapping == submodel
+        else:
+            return slice(None)
+
 
 class FreightZoneData(ZoneData):
     """Container for freight zone data read from input file.

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -293,9 +293,11 @@ class TourPurpose(Purpose):
     
     @property
     def generation_mode_shares(self):
-        shares = {mode: (self.generated_tours[mode].sum() 
-                          / self.generated_tours_all.sum()) for mode in self.modes}
-        return pandas.concat({self.name: pandas.Series(shares, name="mode_share")}, 
+        idx = self.zone_data.is_in_submodel
+        shares = {mode: (self.generated_tours[mode][idx].sum()
+                          / self.generated_tours_all[idx].sum())
+            for mode in self.modes}
+        return pandas.concat({self.name: pandas.Series(shares, name="mode_share")},
                              names=["purpose", "mode"])
     
     @property

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -54,7 +54,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_work"] + model.mode_share[0]["car_leisure"],
-            0.31724308032464517)
+            0.3363155284638638)
         
         print("Model system test done")
 


### PR DESCRIPTION
Outside sub-model area, mode shares can be very strange, so we should omit them from general aggregations. If no matching sub-model is found in aggregations (e.g., because model run is "koko_suomi"), mode shares for all zones are output.

Also tiny refactoring of `_get_mode_tours()`.