### PR TITLE
Remove unnecessary transport_classes list and fix demand matrix validation

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -69,9 +69,8 @@ class AssignmentPeriod(Period):
         if use_stored_speeds:
             for criteria in self.stopping_criteria.values():
                 criteria["max_iterations"] = 0
-        self.transport_classes = (param.private_classes
-                                  + param.local_transit_classes)
-        self._end_assignment_classes = set(self.transport_classes
+        self._end_assignment_classes = set(param.private_classes
+                                           + param.local_transit_classes
             if delete_extra_matrices else param.transport_classes)
         self.assignment_modes: Dict[str, AssignmentMode] = {}
 

--- a/Scripts/assignment/long_dist_period.py
+++ b/Scripts/assignment/long_dist_period.py
@@ -21,8 +21,6 @@ class WholeDayPeriod(AssignmentPeriod):
         self._long_distance_trips_assigned = False
         for criteria in self.stopping_criteria.values():
                 criteria["max_iterations"] = 0
-        self.transport_classes = (param.car_classes
-                                  + param.long_distance_transit_classes)
 
     def prepare(self, dist_unit_cost: Dict[str, float],
                 day_scenario: int, save_matrices: bool):
@@ -105,4 +103,5 @@ class WholeDayPeriod(AssignmentPeriod):
             if self._delete_strat_files:
                 strategy_paths[transit_class].unlink(missing_ok=True)
         self._calc_transit_link_results()
-        return self._get_impedances(self.transport_classes)
+        return self._get_impedances(param.car_classes
+                                    + param.long_distance_transit_classes)

--- a/Scripts/assignment/mock_assignment.py
+++ b/Scripts/assignment/mock_assignment.py
@@ -79,8 +79,6 @@ class MockPeriod(Period):
                  end_assignment_classes: Iterable[str]):
         self.name = name
         self.matrices = matrices
-        self.transport_classes = (param.private_classes
-                                  + param.local_transit_classes)
         self.assignment_modes = param.transport_classes
         self._end_assignment_classes = set(end_assignment_classes)
 

--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -100,7 +100,6 @@ class TransitAssignmentPeriod(OffPeakPeriod):
     """
     def __init__(self, *args, **kwargs):
         AssignmentPeriod.__init__(self, *args, **kwargs)
-        self.transport_classes = param.local_transit_classes
         self._end_assignment_classes -= set(
             param.private_classes + param.truck_classes)
 

--- a/Scripts/travel_iteration.py
+++ b/Scripts/travel_iteration.py
@@ -255,8 +255,8 @@ class ModelSystem:
                                      and car_time_files is None):
                 with self.basematrices.open(
                         "demand", tp, self.ass_model.zone_numbers,
-                        transport_classes=ap.transport_classes) as mtx:
-                    for ass_class in ap.transport_classes:
+                        transport_classes=ap.assignment_modes) as mtx:
+                    for ass_class in ap.assignment_modes:
                         self.dtm.demand[tp][ass_class] = mtx[ass_class]
             soft_mode_impedance[tp] = ap.init_assign()
         if self.long_dist_matrices is not None:
@@ -391,7 +391,7 @@ class ModelSystem:
         tp = ap.name
         demand_sum_string = tp
         with self.resultmatrices.open("demand", tp, zone_numbers, m='w') as mtx:
-            for ass_class in ap.assignment_modes.keys():
+            for ass_class in ap.assignment_modes:
                 demand = self.dtm.demand[tp][ass_class]
                 mtx[ass_class] = demand
                 demand_sum_string += "\t{:8.0f}".format(demand.sum())

--- a/Scripts/validate_inputfiles.py
+++ b/Scripts/validate_inputfiles.py
@@ -203,8 +203,13 @@ def main(args):
                 raise ValueError(msg)
             matrixdata = MatrixData(base_matrices_path)
             for tp in time_periods:
-                with matrixdata.open("demand", tp, zone_numbers[submodel]) as mtx:
-                    for ass_class in param.transport_classes:
+                tc = (param.transit_classes
+                      if param.time_periods[tp] == "TransitAssignmentPeriod"
+                      else param.transport_classes)
+                with matrixdata.open(
+                        "demand", tp, zone_numbers[submodel],
+                        transport_classes=tc) as mtx:
+                    for ass_class in tc:
                         a = mtx[ass_class]
 
     long_dist_result_paths = []


### PR DESCRIPTION
Demand matrices are output to omx based on what is  in `assignment_modes`. To make it clearer and less error prone, now also base demand is read for `assignment_modes`. This makes `transport_classes` list unnecessary.

Also remove requirement for car and truck matrices from TransitAssignmentPeriod ("iltatunti").