### PR TITLE
Add auxiliary tkm results

### DIFF
--- a/Scripts/datahandling/traversaldata.py
+++ b/Scripts/datahandling/traversaldata.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 import parameters.assignment as param
 import numpy
+from typing import Dict
 
-def transform_traversal_data(result_path: Path, zones: list):
+def transform_traversal_data(result_path: Path, zones: list) -> Dict[str, numpy.ndarray]:
     """Processes freight model specific traversal files containing information 
     on amount of transported tons between gate pair as auxiliary demand.
 
@@ -16,7 +17,7 @@ def transform_traversal_data(result_path: Path, zones: list):
     Returns
     ----------
     dict
-        freight transit mode : auxiliary demand
+        freight transit mode : numpy.ndarray
     """
     aux_tons = {}
     for ass_class in param.freight_modes:

--- a/Scripts/datahandling/traversaldata.py
+++ b/Scripts/datahandling/traversaldata.py
@@ -3,9 +3,8 @@ import parameters.assignment as param
 import numpy
 
 def transform_traversal_data(result_path: Path, zones: list):
-    """Processes freight model specific traversal files containing
-    information on amount of transported tons between gate pair.
-    Processed traversal file contents are aggregated as auxiliary matrix.
+    """Processes freight model specific traversal files containing information 
+    on amount of transported tons between gate pair as auxiliary demand.
 
     Parameters
     ----------
@@ -16,14 +15,14 @@ def transform_traversal_data(result_path: Path, zones: list):
 
     Returns
     ----------
-    numpy matrix
-        Aggregated auxiliary demand of freight modes
+    dict
+        freight transit mode : auxiliary demand
     """
-    aux_tons = numpy.zeros([len(zones), len(zones)], dtype=numpy.float32)
+    aux_tons = {}
     for ass_class in param.freight_modes:
         file = result_path / f"{ass_class}.txt"
         if file.exists():
-            aux_tons += read_traversal_file(file, numpy.array(zones))
+            aux_tons[ass_class] = read_traversal_file(file, numpy.array(zones))
             file.unlink()
     return aux_tons
 


### PR DESCRIPTION
This is both feature and a hotfix. Currently purposes with high use of aux transits have surplus of ton demand and ton-kilometers in purpose results txt-file due to auxiliary demand being added into truck ton demand. The problem is fixed here by separating aux demand as its own component in purpose results while at the same time adding the aux demand with truck demand for vehicle calculation.