### PR TITLE
Calculate number of households from household shares

### DIFF
--- a/Scripts/datahandling/zone_variables.json
+++ b/Scripts/datahandling/zone_variables.json
@@ -14,7 +14,15 @@
                     "sh_income_40_59",
                     "sh_income_60_79",
                     "sh_income_80_99",
-                    "sh_income_100_"
+                    "sh_income_100_",
+                    "sh_hh1",
+                    "sh_hh2",
+                    "sh_hh3",
+                    "sh_cars1_hh1",
+                    "sh_cars1_hh2",
+                    "sh_cars1_hh3",
+                    "sh_cars2_hh2",
+                    "sh_cars2_hh3"
                 ]
             },
             {
@@ -32,20 +40,7 @@
             "sport_facility_outdoor",
             "area_leisure_buildings",
             "area_university_buildings",
-            "students_comprehensive",
-            {
-                "total": "households",
-                "shares": [
-                    "sh_hh1",
-                    "sh_hh2",
-                    "sh_hh3",
-                    "sh_cars1_hh1",
-                    "sh_cars1_hh2",
-                    "sh_cars1_hh3",
-                    "sh_cars2_hh2",
-                    "sh_cars2_hh3"
-                ]
-            }
+            "students_comprehensive"
         ],
         "mean": [
             "avg_park_cost",

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -76,7 +76,7 @@ class ZoneData:
         for hh, avg_size in avg_hh_size.items():
             self.share[f"sh_pop_{hh}"] = divide(
                 avg_size*self[f"sh_{hh}"], hh_pop)
-            self[hh] = (self[f"sh_pop_{hh}"] * self["population"] / avg_size)
+            self[hh] = self[f"sh_pop_{hh}"] * self["population"] / avg_size
         self.share["sh_cars1_hh1"] = divide(self["sh_cars1_hh1"], hh_pop)
         self.share["sh_cars1_hh2"] = divide(
             (avg_hh_size["hh2"]*self["sh_cars1_hh2"]


### PR DESCRIPTION
- Remove unnecessary data on total number of households
- Make household share aggregations based on zone population instead of household number