### PR TITLE
Fix forcing number of iterations to one for stored-speed assignment

### DIFF
--- a/Scripts/valma_travel.py
+++ b/Scripts/valma_travel.py
@@ -22,7 +22,7 @@ def main(args):
         else Path(args.long_dist_demand_forecast))
     if args.end_assignment_only:
         iterations = 0
-    elif calculate_long_dist_demand or args.stored_speed_assignment:
+    elif calculate_long_dist_demand or args.stored_speed_assignment is not None:
         iterations = 1
     elif args.iterations > 0:
         iterations = args.iterations


### PR DESCRIPTION
It does not make any sense to run more than one iteration when using stored-speed assignment, because the result will be the same every time. The one-iteration-only enforcement for stored-speed assignment has been temporarily broken, which this PR fixes.