### PR TITLE
Add --model-types argument to validate_inputfiles.py

### DIFF
--- a/Scripts/validate_inputfiles.py
+++ b/Scripts/validate_inputfiles.py
@@ -11,7 +11,7 @@ import utils.log as log
 from utils.validate_network import validate
 from assignment.mock_assignment import MockAssignmentModel
 from datahandling.matrixdata import MatrixData
-from datahandling.zonedata import ZoneData
+from datahandling.zonedata import ZoneData, FreightZoneData
 import parameters.assignment as param
 from valma_travel import BASE_ZONEDATA_FILE
 
@@ -218,8 +218,10 @@ def main(args):
         if long_dist == "calc":
             long_dist_result_paths.append(
                 Path(args.results_path, name, "Matrices", "koko_suomi"))
-    for data_path, submodel, long_dist_forecast, freight_path in zip(
-            forecast_zonedata_paths, args.submodel,
+    model_types = (args.model_types if args.model_types
+                   else ["passenger_transport" for _ in forecast_zonedata_paths])
+    for model_type, data_path, submodel, long_dist_forecast, freight_path in zip(
+            model_types, forecast_zonedata_paths, args.submodel,
             args.long_dist_demand_forecast, args.freight_matrix_paths):
         # Check forecasted zonedata
         if not os.path.exists(data_path):
@@ -227,8 +229,12 @@ def main(args):
                 data_path)
             log.error(msg)
             raise ValueError(msg)
-        forecast_zonedata = ZoneData(
-            Path(data_path), zone_numbers[submodel], submodel)
+        if model_type == "goods_transport":
+            forecast_zonedata = FreightZoneData(
+                Path(data_path), zone_numbers[submodel], submodel)
+        else:
+            forecast_zonedata = ZoneData(
+                Path(data_path), zone_numbers[submodel], submodel)
 
         # Check long-distance base matrices
         if long_dist_forecast not in ("calc", "base"):
@@ -268,6 +274,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--log-format",
         choices={"TEXT", "JSON"},
+    )
+    parser.add_argument(
+        "--model-types",
+        type=str,
+        nargs="+",
+        help=("List of scenario model types "
+              + "('passenger_transport'/'goods_transport'/...)")
     )
     parser.add_argument(
         "-o", "--end-assignment-only",


### PR DESCRIPTION
As a first step, zone data is validated differently for goods transport scenarios. Later we could change input validation more drastically to mirror the differences between travel and freight scenarios.