### PR TITLE
Add initialization of van demand to loop

### DIFF
--- a/Scripts/travel_iteration.py
+++ b/Scripts/travel_iteration.py
@@ -343,8 +343,7 @@ class ModelSystem:
                     Impedance (float 2-d matrix)
         """
         impedance = {}
-        self.dtm.init_demand(
-            [mode for mode in self.travel_modes if mode != "walk"])
+        self.dtm.init_demand({**self.travel_modes, "van": True})
 
         self.dm.calculate_car_ownership(previous_iter_impedance)
 


### PR DESCRIPTION
The missing initialization has caused van traffic to grow between model iterations.
Also remove obsolete "walk" exception. Since #198, missing modes are handled in `DepartureTimeModel`.