### PR TITLE
Add error message if EMME matrix not found

### DIFF
--- a/Scripts/assignment/datatypes/emme_matrix.py
+++ b/Scripts/assignment/datatypes/emme_matrix.py
@@ -67,8 +67,11 @@ class EmmeMatrix:
 
     @property
     def data(self) -> numpy.ndarray:
-        return (self._emme_project.modeller.emmebank.matrix(self.id)
-               .get_numpy_data(scenario_id=self._scenario_id))
+        try:
+            return (self._emme_project.modeller.emmebank.matrix(self.id)
+                    .get_numpy_data(scenario_id=self._scenario_id))
+        except AttributeError:
+            raise AttributeError(f"Matrix {self.description} not found")
 
     @property
     def item(self):


### PR DESCRIPTION
If there is no matrix in EMME matching the gived ID, it will return `None`, resulting in strange error messages. This gives a clearer error message.