### PR TITLE
Set long-dist mode unavailable if main mode less than half of dist

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -217,6 +217,7 @@ class AssignmentPeriod(Period):
         self._check_congestion()
         del mtxs["dist"]
         del mtxs["toll_cost"]
+        del mtxs["train_users"]
         return mtxs
 
     def end_assign(self) -> Dict[str, Dict[str, numpy.ndarray]]:

--- a/Scripts/assignment/datatypes/transit.py
+++ b/Scripts/assignment/datatypes/transit.py
@@ -164,7 +164,7 @@ class TransitMode(AssignmentMode):
         })
         if self.name not in param.long_distance_transit_classes:
             # For daily tours, use main_inv_time for analyzing train usage
-            self.transit_result_specs[1]["modes"] = ['j']
+            self.transit_result_specs[1][subset]["modes"] = ['j', 'r']
         return [
             self.transit_result_specs[0],
             self.transit_result_specs[0][subset],

--- a/Scripts/assignment/datatypes/transit.py
+++ b/Scripts/assignment/datatypes/transit.py
@@ -137,8 +137,7 @@ class TransitMode(AssignmentMode):
         self.inv_cost = self._create_matrix("inv_cost")
         self.inv_time = self._create_matrix("inv_time")
         self.board_cost = self._create_matrix("board_cost")
-        if self.name in param.long_distance_transit_classes:
-            self.main_inv_time = self._create_matrix("main_inv_time")
+        self.main_inv_time = self._create_matrix("main_inv_time")
 
     def _add_park_and_ride(self):
         return False
@@ -156,14 +155,16 @@ class TransitMode(AssignmentMode):
                 "avg_boardings": self.num_board.id,
             },
         }]
-        if self.name in param.long_distance_transit_classes:
-            self.transit_result_specs.append({
-                "type": "EXTENDED_TRANSIT_MATRIX_RESULTS",
-                subset: {
-                    "modes": param.long_dist_transit_modes[self.name],
-                    "actual_in_vehicle_times": self.main_inv_time.id,
-                },
-            })
+        self.transit_result_specs.append({
+            "type": "EXTENDED_TRANSIT_MATRIX_RESULTS",
+            subset: {
+                "modes": param.long_dist_transit_modes[self.name],
+                "actual_in_vehicle_times": self.main_inv_time.id,
+            },
+        })
+        if self.name not in param.long_distance_transit_classes:
+            # For daily tours, use main_inv_time for analyzing train usage
+            self.transit_result_specs[1]["modes"] = ['j']
         return [
             self.transit_result_specs[0],
             self.transit_result_specs[0][subset],
@@ -175,9 +176,12 @@ class TransitMode(AssignmentMode):
         cost = self.inv_cost.data + self.board_cost.data
         time = self.gen_cost.data - self.vot_inv*cost - transfer_penalty
         time[cost > 999999] = 999999
+        mtxs = {"time": time, "cost": cost}
         if self.name in param.long_distance_transit_classes:
             time[self.main_inv_time.data < 0.5*self.inv_time.data] = 999999
-        mtxs = {"time": time, "cost": cost}
+        else:
+            mtxs["train_users"] = self.demand.data
+            mtxs["train_users"][self.main_inv_time.data == 0] = 0
         for mtx_name in param.impedance_output:
             if mtx_name in self._matrices:
                 mtxs[mtx_name] = self._matrices[mtx_name].data

--- a/Scripts/assignment/datatypes/transit.py
+++ b/Scripts/assignment/datatypes/transit.py
@@ -135,9 +135,9 @@ class TransitMode(AssignmentMode):
         self.num_board = self._create_matrix("num_board")
         self.gen_cost = self._create_matrix("gen_cost")
         self.inv_cost = self._create_matrix("inv_cost")
-        self.inv_time = self._create_matrix("inv_time")
         self.board_cost = self._create_matrix("board_cost")
-        self.main_inv_time = self._create_matrix("main_inv_time")
+        self.dist = self._create_matrix("dist")
+        self.main_mode_dist = self._create_matrix("main_mode_dist")
 
     def _add_park_and_ride(self):
         return False
@@ -149,8 +149,8 @@ class TransitMode(AssignmentMode):
             "total_impedance": self.gen_cost.id,
             subset: {
                 "modes": modes,
+                "distance": self.dist.id,
                 "actual_in_vehicle_costs": self.inv_cost.id,
-                "actual_in_vehicle_times": self.inv_time.id,
                 "actual_total_boarding_costs": self.board_cost.id,
                 "avg_boardings": self.num_board.id,
             },
@@ -159,7 +159,7 @@ class TransitMode(AssignmentMode):
             "type": "EXTENDED_TRANSIT_MATRIX_RESULTS",
             subset: {
                 "modes": param.long_dist_transit_modes[self.name],
-                "actual_in_vehicle_times": self.main_inv_time.id,
+                "distance": self.main_mode_dist.id,
             },
         })
         if self.name not in param.long_distance_transit_classes:
@@ -178,10 +178,10 @@ class TransitMode(AssignmentMode):
         time[cost > 999999] = 999999
         mtxs = {"time": time, "cost": cost}
         if self.name in param.long_distance_transit_classes:
-            time[self.main_inv_time.data < 0.5*self.inv_time.data] = 999999
+            time[self.main_mode_dist.data < 0.5*self.dist.data] = 999999
         else:
             mtxs["train_users"] = self.demand.data
-            mtxs["train_users"][self.main_inv_time.data == 0] = 0
+            mtxs["train_users"][self.main_mode_dist.data == 0] = 0
         for mtx_name in param.impedance_output:
             if mtx_name in self._matrices:
                 mtxs[mtx_name] = self._matrices[mtx_name].data

--- a/Scripts/assignment/mock_assignment.py
+++ b/Scripts/assignment/mock_assignment.py
@@ -157,7 +157,7 @@ class MockPeriod(Period):
             self, assignment_classes: Iterable[str],
             impedance_output: Iterable[str] = param.basic_impedance_output):
         impedance_output = [mtx_type for mtx_type in impedance_output
-            if mtx_type != "toll_cost"]
+            if mtx_type not in ("toll_cost", "train_users")]
         mtxs = {mtx_type: self._get_matrices(mtx_type, assignment_classes)
             for mtx_type in impedance_output}
         # TODO This is a temporary solution to maintain backwards compability.

--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -99,6 +99,7 @@ class OffPeakPeriod(AssignmentPeriod):
         for ass_cl in param.car_classes:
             del mtxs["dist"][ass_cl]
         del mtxs["toll_cost"]
+        del mtxs["train_users"]
         return mtxs
 
 
@@ -164,6 +165,7 @@ class TransitAssignmentPeriod(OffPeakPeriod):
         """
         mtxs = self._get_impedances(param.local_transit_classes)
         del mtxs["dist"]
+        del mtxs["train_users"]
         return mtxs
 
     def end_assign(self) -> Dict[str, Dict[str, ndarray]]:

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -722,7 +722,6 @@ transit_impedance_matrices = {
         "fw_time": "actual_first_waiting_times",
     },
     "by_mode_subset": {
-        "inv_time": "actual_in_vehicle_times",
         "board_time": "actual_total_boarding_times",
         "perc_bcost": "perceived_total_boarding_costs",
     },

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -723,6 +723,7 @@ transit_impedance_matrices = {
         "fw_time": "actual_first_waiting_times",
     },
     "by_mode_subset": {
+        "inv_time": "actual_in_vehicle_times",
         "board_time": "actual_total_boarding_times",
         "perc_bcost": "perceived_total_boarding_costs",
     },

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -712,7 +712,8 @@ segment_results = {
     "transfer_boardings": "trb",
 }
 uncongested_transit_time = "base_timtr"
-basic_impedance_output = ["time", "cost", "dist", "toll_cost", "inv_time"]
+basic_impedance_output = ["time", "cost", "dist", "toll_cost", "inv_time",
+                          "train_users"]
 mixed_mode_output = ["car_time", "transfer_time", "park_cost"]
 impedance_output = basic_impedance_output + mixed_mode_output
 transit_impedance_matrices = {


### PR DESCRIPTION
Long-distance transit (i.e., train, coach, airplane) _assignment_ is performed as usual, enforcing usage of the main mode, but without restriction of the extent of usage. Hence, the distance traveled by the main mode can in some cases be a very short part of the total distance traveled. In these cases, we now set the long-distance transit mode as unavailable in _demand calculation_ by setting its travel time to 999999.

Also use the same analysis method for output of transit_work and transit_leisure demand using j and r modes (train) in EMME.

TODO:
- Remove dist matrix before demand calculation