### PR TITLE
Refactor walk assignment and remove deprecated STANDARD_TRANSIT_ASSIGNMENT

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -173,7 +173,6 @@ class AssignmentPeriod(Period):
         self.assignment_modes.update(mixed_modes)
         self._calc_boarding_penalties()
         self._set_transit_vdfs()
-        self._set_walk_time()
         self._long_distance_trips_assigned = False
 
     def init_assign(self):
@@ -652,15 +651,6 @@ class AssignmentPeriod(Period):
         self.emme_project.car_assignment(
             specification=self.bike_mode.spec, scenario=scen)
         log.info("Bike assignment performed for scenario " + str(scen.id))
-
-    def _assign_pedestrians(self):
-        """Perform pedestrian assignment for one scenario."""
-        self.walk_mode.init_matrices()
-        self._set_walk_time()
-        log.info("Pedestrian assignment started...")
-        self.emme_project.pedestrian_assignment(
-            specification=self.walk_mode.spec, scenario=self.emme_scenario)
-        log.info("Pedestrian assignment performed for scenario " + str(self.emme_scenario.id))
 
     def _calc_extra_wait_time(self):
         """Calculate extra waiting time for one scenario."""

--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -173,6 +173,7 @@ class AssignmentPeriod(Period):
         self.assignment_modes.update(mixed_modes)
         self._calc_boarding_penalties()
         self._set_transit_vdfs()
+        self._set_walk_time()
         self._long_distance_trips_assigned = False
 
     def init_assign(self):
@@ -719,7 +720,6 @@ class AssignmentPeriod(Period):
                         calc_network_results=False, delete_strat_files=False):
         """Perform transit assignment for one scenario."""
         self._calc_extra_wait_time()
-        self._set_walk_time()
         log.info("Transit assignment started...")
         for i, transit_class in enumerate(transit_classes):
             tc: TransitMode = self.assignment_modes[transit_class]

--- a/Scripts/assignment/emme_bindings/emme_project.py
+++ b/Scripts/assignment/emme_bindings/emme_project.py
@@ -97,8 +97,6 @@ class EmmeProject:
             "inro.emme.network_calculation.network_calculator")
         self.car_assignment = self.modeller.tool(
             "inro.emme.traffic_assignment.sola_traffic_assignment")
-        self.pedestrian_assignment = self.modeller.tool(
-            "inro.emme.transit_assignment.standard_transit_assignment")
         self.transit_assignment = self.modeller.tool(
             "inro.emme.transit_assignment.extended_transit_assignment")
         self.congested_assignment = self.modeller.tool(

--- a/Scripts/assignment/emme_bindings/mock_project.py
+++ b/Scripts/assignment/emme_bindings/mock_project.py
@@ -396,9 +396,6 @@ class MockProject:
         }
         return report
 
-    def pedestrian_assignment(self, *args, **kwargs):
-        pass
-
     _transit_classes = set()
 
     def transit_assignment(self, specification, scenario=None,

--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -2,6 +2,7 @@ from typing import Dict, Iterable
 from numpy import ndarray
 import copy
 
+import utils.log as log
 from assignment.assignment_period import AssignmentPeriod
 from assignment.long_dist_period import WholeDayPeriod
 from assignment.datatypes.transit import TransitMode
@@ -55,7 +56,10 @@ class OffPeakPeriod(AssignmentPeriod):
 
     def init_assign(self):
         self._init_assign_transit()
-        self._assign_pedestrians()
+        log.info("Pedestrian assignment started...")
+        self._set_walk_time()
+        self.walk_mode.assign()
+        log.info(f"Pedestrians assigned for scenario {self.emme_scenario.id}")
         self._set_bike_vdfs()
         self._assign_bikes()
         return self.get_soft_mode_impedances()

--- a/Scripts/assignment/off_peak_period.py
+++ b/Scripts/assignment/off_peak_period.py
@@ -57,7 +57,6 @@ class OffPeakPeriod(AssignmentPeriod):
     def init_assign(self):
         self._init_assign_transit()
         log.info("Pedestrian assignment started...")
-        self._set_walk_time()
         self.walk_mode.assign()
         log.info(f"Pedestrians assigned for scenario {self.emme_scenario.id}")
         self._set_bike_vdfs()


### PR DESCRIPTION
This fixes problem with very short walk times, which was due to deprecated use of ul3 as walk time attribute hard-coded in walk mode.