### PR TITLE
Fix freight purpose creation error handling with unknown keys

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -651,28 +651,26 @@ class FreightPurpose(Purpose):
     ----------
     specification : dict
         Model parameter specifications
-    zone_data : ZoneData
-        Data used for all demand calculations
+    zone_data : Dict[str, FreightZoneData]
+        Model area (domestic/foreign) : Data used for all demand calculations
     resultdata : ResultData
         Writer object to result directory
     costdata : Dict[str, dict]
         Freight mode (truck/freight_train/ship) : mode
             Mode (truck/trailer_truck...) : unit cost name
                 unit cost name : unit cost value
-    category : str
-        purpose modelling category, within Finland as 'domestic, 
-        outside Finland as 'foreign'
     """
-    def __init__(self, specification, zone_data, resultdata, costdata, category):
-        args = (self, specification, zone_data, resultdata)
-        Purpose.__init__(*args)
+    def __init__(self, specification, zone_data, resultdata, costdata):
+        Purpose.__init__(self, specification, zone_data, resultdata)
         self.costdata = costdata
-        self.model_category = category
+        self.model_category = list(zone_data)[0]
 
         if specification["struct"] == "dest>mode":
-            self.model = logit.DestModeModel(*args)
+            self.model = logit.DestModeModel(self, specification, zone_data[self.model_category], 
+                                             resultdata)
         else:
-            self.model = logit.ModeDestModel(*args)
+            self.model = logit.ModeDestModel(self, specification, zone_data[self.model_category], 
+                                             resultdata)
         self.modes = list(self.model.mode_choice_param)
 
         if specification.get("logistics_module"):

--- a/Scripts/tests/unit/test_freight_demand.py
+++ b/Scripts/tests/unit/test_freight_demand.py
@@ -33,6 +33,7 @@ class FreightModelTest(unittest.TestCase):
             costdata = json.load(file)
         purposes = create_purposes(PARAMETERS_PATH / "domestic", zonedata, 
                                    resultdata, costdata["freight"])
+        self.assertGreaterEqual(len(purposes), 1)
         
         time_impedance = omx.open_file(TEST_MATRICES / "freight_time.omx", "r")
         dist_impedance = omx.open_file(TEST_MATRICES / "freight_dist.omx", "r")

--- a/Scripts/utils/freight_utils.py
+++ b/Scripts/utils/freight_utils.py
@@ -41,14 +41,14 @@ def create_purposes(parameters_path: Path, zonedata: FreightZoneData,
     for file in parameters_path.rglob("*.json"):
         commodity_params = json.loads(file.read_text("utf-8"))
         commodity = commodity_params["name"]
-        try:
-            purpose_cost = costdata[commodity_conversion[commodity]]
-            purposes[commodity] = FreightPurpose(commodity_params, zonedata, 
-                                                 resultdata, purpose_cost,
-                                                 parameters_path.stem)
-        except KeyError:
+        purpose_cost = costdata.get(commodity_conversion[commodity])
+        if not purpose_cost:
             log.warn(f"Aggregated commodity class '{commodity_conversion[commodity]}' "
-                      f"for commodity '{commodity}' not found in costs json")
+                     f"for commodity '{commodity}' not found in costs json")
+            continue
+        purposes[commodity] = FreightPurpose(commodity_params, 
+                                             {parameters_path.stem: zonedata},
+                                             resultdata, purpose_cost)
     return purposes
 
 class StoreDemand():


### PR DESCRIPTION
This PR also fixes the problem where FreightZoneData was still passed to FreightPurpose as class object instead of as dict. The faulty error handling caused this to slip through.