### PR TITLE
Add new calibration input

### DIFF
--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -93,6 +93,15 @@ This is a .json file, containing transport cost data.
 If you are trying the test test network and data, try
 `"C:\\FILL_YOUR_PATH\\model-system\\Scripts\\tests\\test_data\\Scenario_input_data\\costdata.json"`.
 
+### `MODE_DEST_CALIBRATION_PATH`
+
+File path (.json) where mode and destination choice calibration coefficients
+are found.
+
+### `MUNICIPALITY_CALIBRATION_PATH`
+
+File path (.txt) where municipality calibration coefficients are found
+
 ### `LONG_DIST_DEMAND_FORECAST`
 
 If 'calc', runs assigment with free-flow speed and calculates demand for long-distance trips.

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -11,7 +11,7 @@ import json
 import parameters.zone as param
 import utils.log as log
 from datatypes.zone import Zone, ZoneAggregations, avg
-from models.logit import divide, log as ln
+from models.logit import divide
 
 
 class ZoneData:
@@ -73,8 +73,8 @@ class ZoneData:
         self.zones = {number: Zone(number, self.aggregations)
             for number in self.zone_numbers}
         self.nr_zones = len(self.zone_numbers)
-        self._municipality_calib: Dict[str, pandas.Series] = {mode: ln(params)
-                       for mode, params in municipality_calibration.items()}
+        self._municip_calib: Dict[str, pandas.Series] = {mode: numpy.log(params)
+            for mode, params in municipality_calibration.items()}
         self._add_transformations(data, extra_dummies, car_dist_cost)
 
     def _add_transformations(self,
@@ -237,7 +237,7 @@ class ZoneData:
             elif "municipality_calibration" in key:
                 try:
                     # Try to find mode-specific calibration matrix
-                    calib = self._municipality_calib[key.split('_')[-1]]
+                    calib = self._municip_calib[key.split('_')[-1]]
                 except KeyError:
                     return 0
                 else:

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -11,9 +11,8 @@ import json
 import parameters.zone as param
 import utils.log as log
 from datatypes.zone import Zone, ZoneAggregations, avg
+from models.logit import divide, log as ln
 
-def divide(a, b):
-    return numpy.divide(a, b, out=numpy.zeros_like(a), where=b!=0)
 
 class ZoneData:
     """Container for zone data read from input file.
@@ -27,6 +26,11 @@ class ZoneData:
     zone_mapping : str
             Name of column where mapping between data zones (index)
             and assignment zones
+    municipality_calibration : dict
+        key : str
+            Transport mode (car_work/bike/...)
+        value : pandas.Series
+            Municipality-pair calibration factors
     extra_dummies : dict
         key : str
             Name of aggregation level
@@ -41,6 +45,7 @@ class ZoneData:
     def _init_data(self, data_path: Path, zone_numbers: Sequence,
                  zone_mapping: str, data_type: str = "domestic_travel",
                  model_area: str = "domestic",
+                 municipality_calibration: Dict[str, pandas.Series] = {},
                  extra_dummies: Dict[str, Sequence[str]] = {},
                  car_dist_cost: Optional[float] = None):
         self._values = {}
@@ -68,6 +73,8 @@ class ZoneData:
         self.zones = {number: Zone(number, self.aggregations)
             for number in self.zone_numbers}
         self.nr_zones = len(self.zone_numbers)
+        self._municipality_calib: Dict[str, pandas.Series] = {mode: ln(params)
+                       for mode, params in municipality_calibration.items()}
         self._add_transformations(data, extra_dummies, car_dist_cost)
 
     def _add_transformations(self,
@@ -227,6 +234,16 @@ class ZoneData:
                 beeline, lower, upper, _ = key.split('_')
                 mtx = self[beeline]
                 return (mtx > int(lower)) & (mtx <= int(upper))[bounds, :]
+            elif "municipality_calibration" in key:
+                try:
+                    # Try to find mode-specific calibration matrix
+                    calib = self._municipality_calib[key.split('_')[-1]]
+                except KeyError:
+                    return 0
+                else:
+                    idx = self.aggregations.mappings["municipality"].values
+                    return calib.unstack("attraction").reindex(
+                        index=idx, columns=idx, fill_value=0.0).values[bounds, :]
             else:
                 raise KeyError(err)
         if val.ndim == 1: # If not a compound (i.e., matrix)

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -73,8 +73,7 @@ class ZoneData:
         self.zones = {number: Zone(number, self.aggregations)
             for number in self.zone_numbers}
         self.nr_zones = len(self.zone_numbers)
-        self._municip_calib: Dict[str, pandas.Series] = {mode: numpy.log(params)
-            for mode, params in municipality_calibration.items()}
+        self._municip_calib = municipality_calibration
         self._add_transformations(data, extra_dummies, car_dist_cost)
 
     def _add_transformations(self,

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -129,6 +129,7 @@ class ZoneData:
         self["within_municipality"] = within_municipality
         self["outside_municipality"] = ~within_municipality
         dummies = {
+            "zone": {},
             "subarea": {
                 "Helsingin_kantakaupunki",
                 "Tampereen_kantakaupunki",
@@ -145,7 +146,11 @@ class ZoneData:
                 self[dummy] = self.dummy(division_type, dummy)
 
     def dummy(self, division_type, name, bounds=slice(None)):
-        dummy = self.aggregations.mappings[division_type][bounds] == name
+        if division_type == "zone":
+            dummy = pandas.Series(
+                self.zone_numbers == int(name), self.zone_numbers)
+        else:
+            dummy = self.aggregations.mappings[division_type][bounds] == name
         if not dummy.any():
             log.warn(f"Dummy variable {name} not found in {division_type}")
         return dummy

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 import utils.log
 
 
-def log(a: numpy.array):
+def log(a: numpy.ndarray):
     with numpy.errstate(divide="ignore"):
         return numpy.log(a)
 
@@ -101,6 +101,7 @@ class LogitModel:
 
     def _calc_dest_util(self, mode: str, impedance: dict) -> numpy.ndarray:
         b = self.dest_choice_param[mode]
+        b["attraction"][f"municipality_calibration_{mode}"] = 1.0
         utility = numpy.zeros_like(next(iter(impedance.values())))
         impedance["attraction_size"] = self._add_zone_util(
             numpy.zeros_like(utility), b["attraction_size"])

--- a/Scripts/tests/integration/test_data_handling.py
+++ b/Scripts/tests/integration/test_data_handling.py
@@ -14,6 +14,8 @@ TEST_DATA_PATH = Path(__file__).parent.parent / "test_data"
 RESULTS_PATH = TEST_DATA_PATH / "Results" / "test"
 ZONEDATA_PATH = TEST_DATA_PATH / "Scenario_input_data" / "zonedata_test.gpkg"
 COSTDATA_PATH = TEST_DATA_PATH / "Scenario_input_data" / "costdata.json"
+MODE_DEST_CALIBRATION_PATH = TEST_DATA_PATH / "Scenario_input_data" / "mode_dest_calibration.json"
+MUNICIPALITY_CALIBRATION_PATH = TEST_DATA_PATH / "Scenario_input_data" / "municipality_calibration.txt"
 BASE_MATRICES_PATH = TEST_DATA_PATH / "Scenario_input_data" / "Matrices"
 INTERNAL_ZONES = [
     202, 1344, 1755, 2037, 2129, 2224, 2333, 2413, 2519, 2621, 2707, 2814, 2918,

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -13,6 +13,8 @@ from tests.integration.test_data_handling import (
     ZONEDATA_PATH,
     COSTDATA_PATH,
     BASE_MATRICES_PATH,
+    MODE_DEST_CALIBRATION_PATH,
+    MUNICIPALITY_CALIBRATION_PATH
 )
 
 
@@ -31,8 +33,9 @@ class ModelTest(unittest.TestCase):
         ass_model = MockAssignmentModel(MatrixData(
             RESULTS_PATH / "Matrices" / "uusimaa"))
         model = ModelSystem(
-            ZONEDATA_PATH, COSTDATA_PATH, ZONEDATA_PATH,
-            BASE_MATRICES_PATH, RESULTS_PATH, ass_model, "uusimaa")
+            ZONEDATA_PATH, COSTDATA_PATH, BASE_MATRICES_PATH, RESULTS_PATH,
+            ass_model, "uusimaa", MODE_DEST_CALIBRATION_PATH,
+            MUNICIPALITY_CALIBRATION_PATH)
         impedance = model.assign_base_demand()
         for ap in ass_model.assignment_periods:
             tp = ap.name
@@ -64,8 +67,8 @@ class ModelTest(unittest.TestCase):
             MatrixData(RESULTS_PATH / "Matrices" / "koko_suomi"),
             use_free_flow_speeds=True, time_periods={"vrk": "WholeDayPeriod"})
         model = ModelSystem(
-            ZONEDATA_PATH, COSTDATA_PATH, ZONEDATA_PATH,
-            BASE_MATRICES_PATH, RESULTS_PATH, ass_model, "koko_suomi")
+            ZONEDATA_PATH, COSTDATA_PATH, BASE_MATRICES_PATH, RESULTS_PATH,
+            ass_model, "koko_suomi")
         impedance = model.assign_base_demand()
 
         print("Adding demand and assigning")

--- a/Scripts/tests/test_data/Scenario_input_data/costdata.json
+++ b/Scripts/tests/test_data/Scenario_input_data/costdata.json
@@ -41,13 +41,6 @@
             "car_pax": 1.0
         }
     },
-    "area_calibration": {
-        "subarea": {
-            "Helsingin kantakaupunki": {
-                "car_work":  0.0
-            }
-        }
-    },
     "freight": {
         "kemiat": {
             "truck": {

--- a/Scripts/tests/test_data/Scenario_input_data/mode_dest_calibration.json
+++ b/Scripts/tests/test_data/Scenario_input_data/mode_dest_calibration.json
@@ -1,0 +1,16 @@
+{
+    "mode_choice_calibration": {
+        "subarea": {
+            "Helsingin kantakaupunki": {
+                "car_work":  0.0
+            }
+        }
+    },
+    "destination_choice_calibration": {
+        "subarea": {
+            "Helsingin kantakaupunki": {
+                "transit_work":  0.0
+            }
+        }
+    }
+}

--- a/Scripts/tests/test_data/Scenario_input_data/mode_dest_calibration.json
+++ b/Scripts/tests/test_data/Scenario_input_data/mode_dest_calibration.json
@@ -7,6 +7,11 @@
         }
     },
     "destination_choice_calibration": {
+        "zone": {
+            "202": {
+                "car_work": 0.0
+            }
+        },
         "subarea": {
             "Helsingin kantakaupunki": {
                 "transit_work":  0.0

--- a/Scripts/tests/test_data/Scenario_input_data/municipality_calibration.txt
+++ b/Scripts/tests/test_data/Scenario_input_data/municipality_calibration.txt
@@ -1,0 +1,3 @@
+generation	attraction	car_work	bike
+Espoo	Helsinki	1.0	1.0
+Kauniainen	Helsinki	1.0	1.0

--- a/Scripts/tests/test_data/Scenario_input_data/municipality_calibration.txt
+++ b/Scripts/tests/test_data/Scenario_input_data/municipality_calibration.txt
@@ -1,3 +1,3 @@
 generation	attraction	car_work	bike
-Espoo	Helsinki	1.0	1.0
-Kauniainen	Helsinki	1.0	1.0
+Espoo	Helsinki	0.0	0.0
+Kauniainen	Helsinki	0.0	0.0

--- a/Scripts/travel_iteration.py
+++ b/Scripts/travel_iteration.py
@@ -48,6 +48,11 @@ class ModelSystem:
         can be EmmeAssignmentModel or MockAssignmentModel
     submodel: str
         Name of submodel, used for choosing appropriate zone mapping
+    mode_dest_calibration_path : Path (optional)
+        File path (.json) where mode and destination choice calibration
+        coefficients are found
+    municipality_calibration_path : Path (optional)
+        File path (.txt) where municipality calibration coefficients are found
     long_dist_matrices_path: Path (optional)
         Directory path where long-distance demand is found.
         If None, long-distance demand is taken from base matrices.
@@ -59,11 +64,12 @@ class ModelSystem:
     def __init__(self,
                  zone_data_path: Path,
                  cost_data_path: Path,
-                 base_zone_data_path: Path,
                  base_matrices_path: Path,
                  results_path: Path,
                  assignment_model: AssignmentModel,
                  submodel: str,
+                 mode_dest_calibration_path: Optional[Path] = None,
+                 municipality_calibration_path: Optional[Path] = None,
                  long_dist_matrices_path: Optional[Path] = None,
                  freight_matrices_path: Optional[Path] = None):
         self.ass_model = cast(Union[MockAssignmentModel,EmmeAssignmentModel], assignment_model) #type checker hint
@@ -79,11 +85,26 @@ class ModelSystem:
         self.car_dist_cost = cost_data["car_cost"]
         self.transit_cost = {data.pop("id"): data for data
             in cost_data["transit_cost"].values()}
-        extra_dummies = cost_data.get("area_calibration", {})
+        if mode_dest_calibration_path is None:
+            mode_dummies = {}
+            dest_dummies = {}
+        else:
+            calibration_data: dict = json.loads(
+                mode_dest_calibration_path.read_text("utf-8"))
+            mode_dummies = calibration_data["mode_choice_calibration"]
+            dest_dummies = calibration_data["destination_choice_calibration"]
+        extra_dummies = {**mode_dummies, **dest_dummies}
+        if municipality_calibration_path is None:
+            municip_calib = {}
+        else:
+            municip_calib = pandas.read_csv(
+                municipality_calibration_path, sep="\t",
+                index_col=["generation", "attraction"]).to_dict("series")
         self._zone_datas = {
             model_area: ZoneData(
                 zone_data_path, self.zone_numbers, submodel,
-                model_area=model_area, extra_dummies=extra_dummies,
+                model_area=model_area, municipality_calibration=municip_calib,
+                extra_dummies=extra_dummies,
                 car_dist_cost=self.car_dist_cost["car_work"]
             ) for model_area in ["domestic"]}
 
@@ -98,12 +119,18 @@ class ModelSystem:
         other_leisure_purposes = []
         for file in parameters_path.rglob("*.json"):
             specification = json.loads(file.read_text("utf-8"))
-            for dummies in extra_dummies.values():
+            for dummies in mode_dummies.values():
                 for subarea in dummies:
                     for mode, coeff in dummies[subarea].items():
                         if mode in specification["mode_choice"]:
                             (specification["mode_choice"][mode]
                                           ["generation"][subarea]) = coeff
+            for dummies in dest_dummies.values():
+                for subarea in dummies:
+                    for mode, coeff in dummies[subarea].items():
+                        if mode in specification["destination_choice"]:
+                            (specification["destination_choice"][mode]
+                                          ["attraction"][subarea]) = coeff
             purpose = new_tour_purpose(
                 specification, self._zone_datas, self.resultdata,
                 cost_data["cost_changes"])

--- a/Scripts/utils/config.py
+++ b/Scripts/utils/config.py
@@ -82,6 +82,8 @@ def create_config(config: dict):
         "CAR_END_ASSIGNMENT_ONLY": False,
         "LONG_DIST_DEMAND_FORECAST": None,
         "FREIGHT_MATRIX_PATH": None,
+        "MODE_DEST_CALIBRATION_PATH": None,
+        "MUNICIPALITY_CALIBRATION_PATH": None,
         "STORED_SPEED_ASSIGNMENT": None,
         "RUN_AGENT_SIMULATION": False,
         "DO_NOT_USE_EMME": False,

--- a/Scripts/valma_travel.py
+++ b/Scripts/valma_travel.py
@@ -29,7 +29,6 @@ def main(args):
     else:
         raise ArgumentTypeError(
             "Iteration number {} not valid".format(args.iterations))
-    base_zonedata_path = Path(args.baseline_data_path, BASE_ZONEDATA_FILE)
     base_matrices_path = Path(args.baseline_data_path, "Matrices")
     freight_matrices_path = (Path(args.freight_matrix_path)
         if args.freight_matrix_path is not None else None)
@@ -99,8 +98,10 @@ def main(args):
     # and providing demand calculations as Python modules)
     # Read input matrices (.omx) and zonedata (.csv)
     log.info("Initializing matrices and models...", extra=log_extra)
-    model_args = (forecast_zonedata_path, cost_data_path, base_zonedata_path,
+    model_args = (forecast_zonedata_path, cost_data_path,
                   base_matrices_path, results_path, ass_model, args.submodel,
+                  args.mode_dest_calibration_path,
+                  args.municipality_calibration_path,
                   long_dist_matrices_path, freight_matrices_path)
     model = (AgentModelSystem(*model_args) if args.is_agent_model
              else ModelSystem(*model_args))
@@ -261,7 +262,6 @@ if __name__ == "__main__":
         "--results-path",
         type=str,
         help="Path to folder where result data is saved to."),
-    # HELMET scenario input data
     parser.add_argument(
         "--submodel",
         type=str,
@@ -290,6 +290,14 @@ if __name__ == "__main__":
         "--cost-data-path",
         type=str,
         help="Path to file containing transport cost data"),
+    parser.add_argument(
+        "--mode-dest-calibration-path",
+        type=str,
+        help="Path to file containing mode and destination choice calibration data"),
+    parser.add_argument(
+        "--municipality-calibration-path",
+        type=str,
+        help="Path to file containing municipality calibration data"),
     parser.add_argument(
         "--iterations",
         type=int,


### PR DESCRIPTION
### `MODE_DEST_CALIBRATION_PATH`

File path (.json) where mode and destination choice calibration coefficients
are found. These are dummy _additions_ to utility.

### `MUNICIPALITY_CALIBRATION_PATH`

File path (.txt) where municipality calibration coefficients are found. These are dummy _additions_ to destination choice utility.

### Open questions:
- What about freight?