### PR TITLE
link parameter changes and traffic lights

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -384,9 +384,15 @@ class AssignmentPeriod(Period):
                         link.volume_delay_func = 91
                     else:
                         link.volume_delay_func = roadclass.volume_delay_func
-                link.data1 = roadclass.lane_capacity
-                link.data2 = roadclass.free_flow_speed
-                link[param.free_flow_time_attr] = (60 * link.length
+                if link["#traffic_light"] and roadclass.free_flow_speed < 65:
+                    link.data1 = roadclass.lane_capacity * param.traffic_light_capacity_factor
+                    link.data2 = roadclass.free_flow_speed * param.traffic_light_speed_factor
+                    link[param.free_flow_time_attr] = (60 * link.length
+                                                   / (roadclass.free_flow_speed * param.traffic_light_speed_factor))
+                else:
+                    link.data1 = roadclass.lane_capacity
+                    link.data2 = roadclass.free_flow_speed
+                    link[param.free_flow_time_attr] = (60 * link.length
                                                    / roadclass.free_flow_speed)
             elif linktype in param.custom_roadtypes:
                 # Custom car link

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -30,7 +30,7 @@ roadclasses = {
     18: RoadClass("arterial", "any", 3, 1400, 97, 0.309),
     19: RoadClass("arterial", "any", 3, 1400, 90, 0.309),
     20: RoadClass("arterial", "any", 3, 1350, 81, 0.370),
-    21: RoadClass("arterial", "any", 3, 1450, 61, 0.492),
+    21: RoadClass("arterial", "any", 3, 1200, 58, 0.492),
     22: RoadClass("arterial", "any", 3, 1100, 73, 0.492),
     23: RoadClass("arterial", "any", 3, 1250, 54, 0.556),
     24: RoadClass("arterial", "any", 3, 1100, 63, 0.492),
@@ -43,16 +43,18 @@ roadclasses = {
     31: RoadClass("collector", "any", 5, 900, 41, 0.732),
     32: RoadClass("collector", "any", 5, 900, 36, 0.833),
     33: RoadClass("collector", "any", 5, 750, 36, 0.833),
-    34: RoadClass("collector", "any", 5, 700, 41, 0.732),
+    34: RoadClass("collector", "any", 5, 600, 36, 0.732),
     35: RoadClass("local", "any", 5, 700, 30, 1.000),
-    36: RoadClass("local", "any", 5, 600, 30, 1.000),
-    37: RoadClass("local", "any", 5, 500, 30, 1.000),
-    38: RoadClass("local", "any", 5, 500, 23, 1.304),
+    36: RoadClass("local", "any", 5, 600, 25, 1.000),
+    37: RoadClass("local", "any", 5, 550, 20, 1.000),
+    38: RoadClass("local", "any", 5, 500, 18, 1.304),
     39: RoadClass("local", "any", 5, 700, 20, 1.304),
-    40: RoadClass("local", "any", 5, 600, 20, 1.304),
-    41: RoadClass("local", "any", 5, 500, 20, 1.304),
+    40: RoadClass("local", "any", 5, 600, 15, 1.304),
+    41: RoadClass("local", "any", 5, 500, 12, 1.304),
     44: RoadClass("ferry", "any", 11, 500, 20, 1.000),
 }
+traffic_light_capacity_factor = 0.9
+traffic_light_speed_factor = 0.85
 connector_link_types = (84, 85, 86, 87, 88, 98, 99)
 connector = RoadClass("connector", "any", 99, 0, 50, 0)
 roadclasses.update({linktype: connector for linktype in connector_link_types})

--- a/Scripts/tests/test_data/Network/netfield_links_test.txt
+++ b/Scripts/tests/test_data/Network/netfield_links_test.txt
@@ -1,5 +1,6 @@
 t network_fields
 #buslane LINK BOOLEAN ''
+#traffic_light LINK BOOLEAN ''
 #car_time_aht LINK REAL ''
 #car_time_iht LINK REAL ''
 #car_time_it LINK REAL ''
@@ -11,4 +12,4 @@ t network_fields
 #hinta_pt LINK REAL ''
 #hinta_vrk LINK REAL ''
 end network_fields
-   inode    jnode  #buslane #car_time_aht #car_time_iht #car_time_it #car_time_pt #car_time_vrk #extra_cost #hinta_aht #hinta_iht #hinta_pt #hinta_vrk
+   inode    jnode  #buslane #traffic_light #car_time_aht #car_time_iht #car_time_it #car_time_pt #car_time_vrk #extra_cost #hinta_aht #hinta_iht #hinta_pt #hinta_vrk


### PR DESCRIPTION
Improves network hierarchy, decreases car speed on downtowns and makes traffic light descirption more clear. Shouldn't be merged before networks with #traffic_light attribute is in use.