### PR TITLE
Update fetching impedances for marine ship modes

### DIFF
--- a/Scripts/assignment/freight_assignment.py
+++ b/Scripts/assignment/freight_assignment.py
@@ -202,13 +202,12 @@ class FreightAssignmentPeriod(AssignmentPeriod):
         return port_ids
 
     def _get_marine_transit_lines(self, is_export: bool) -> dict:
-        """Get list of marine transit lines depending whether data fetching
-        is done for exporting or importing.
+        """Fetch list of marine transit lines.
 
         Parameters
         ----------
         is_export : bool
-            Whether data should be fetched for export (True) or import (False)
+            Fetch export specific transit lines. Else import specific
         
         Returns
         -------
@@ -241,7 +240,7 @@ class FreightAssignmentPeriod(AssignmentPeriod):
         """Create inf matrix and insert attribute values into origin and
         destination indices of the matrix. OD pairs without trade route will 
         retain their inf attribute value.
-.
+
         Parameters
         ----------
         transit_lines : list[Transit line]

--- a/Scripts/assignment/freight_assignment.py
+++ b/Scripts/assignment/freight_assignment.py
@@ -221,17 +221,12 @@ class FreightAssignmentPeriod(AssignmentPeriod):
         ship_modes = {mode for nesting in param.freight_marine_modes.values() 
                       for mode in nesting}
         for line in self.emme_scenario.get_network().transit_lines():
-            if line.mode.id not in ship_modes:
+            # Marine transit line id in format port-port_shiptype
+            if line.mode.id not in ship_modes or not line.id[0:2].isalpha():
                 continue
-            
-            id_split = line.id.split("_")[0]
-            try:
-                int(id_split)
-                continue
-            except ValueError:
-                starts_in_fi = line.id[0:2] == "FI"
-                if ((starts_in_fi and is_export) or (not starts_in_fi and not is_export)):
-                    mode_transit_lines[line.mode.id].append(line)
+            starts_in_fi = line.id[0:2] == "FI"
+            if ((starts_in_fi and is_export) or (not starts_in_fi and not is_export)):
+                mode_transit_lines[line.mode.id].append(line)
         return mode_transit_lines
 
     def _line_data_to_matrix(self, transit_lines: list, attribute: str,

--- a/Scripts/assignment/freight_assignment.py
+++ b/Scripts/assignment/freight_assignment.py
@@ -1,6 +1,7 @@
 from typing import Dict, Tuple
 from pathlib import Path
 import numpy
+from collections import defaultdict
 
 import utils.log as log
 import parameters.assignment as param
@@ -162,13 +163,15 @@ class FreightAssignmentPeriod(AssignmentPeriod):
         destinations = self._filter_border_points(destinations)
         orig_mapping = {pid: idx for idx, pid in enumerate(origins)}
         dest_mapping = {pid: idx for idx, pid in enumerate(destinations)}
+        transit_lines = self._get_marine_transit_lines(is_export)
+        
         ship_impedances = {}
-        for ship, modes in param.freight_marine_modes.items():
-            ship_impedances[ship] = {}
+        for marine_ship, modes in param.freight_marine_modes.items():
+            ship_impedances[marine_ship] = {}
             ship_mode = next(iter(modes))
             for key, attr in param.ship_attrs.items():
-                ship_impedances[ship][key] = self._line_data_to_matrix(
-                    ship_mode, attr, orig_mapping, dest_mapping, is_export)
+                ship_impedances[marine_ship][key] = self._line_data_to_matrix(
+                    transit_lines[ship_mode], attr, orig_mapping, dest_mapping)
         return ship_impedances, origins, destinations
 
     def _filter_border_points(self, border_data: dict) -> Dict[str, int]:
@@ -198,22 +201,51 @@ class FreightAssignmentPeriod(AssignmentPeriod):
                     if border_data[pid]["id"] in zone_numbers}
         return port_ids
 
-    def _line_data_to_matrix(self, ship_mode: str,
-                             attribute: str,
-                             orig_mapping: Dict[str, int],
-                             dest_mapping: Dict[str, int],
-                             is_export: bool) -> numpy.ndarray:
-        """Create inf matrix and insert attribute values into origin and
-        destination indices of the matrix.
-
-        OD pairs without trade route will retain their inf attribute value.
-        Fetching is performed only for those transit lines that match
-        trade direction (export/import).
+    def _get_marine_transit_lines(self, is_export: bool) -> dict:
+        """Get list of marine transit lines depending whether data fetching
+        is done for exporting or importing.
 
         Parameters
         ----------
-        ship_mode : str
-            Mode of freight ship
+        is_export : bool
+            Whether data should be fetched for export (True) or import (False)
+        
+        Returns
+        -------
+        dict
+            marine mode : str
+                marine ship mode
+            transit lines : list
+                Emme Transit line objects
+        """
+        mode_transit_lines = defaultdict(list)
+        ship_modes = {mode for nesting in param.freight_marine_modes.values() 
+                      for mode in nesting}
+        for line in self.emme_scenario.get_network().transit_lines():
+            if line.mode.id not in ship_modes:
+                continue
+            
+            id_split = line.id.split("_")[0]
+            try:
+                int(id_split)
+                continue
+            except ValueError:
+                starts_in_fi = line.id[0:2] == "FI"
+                if ((starts_in_fi and is_export) or (not starts_in_fi and not is_export)):
+                    mode_transit_lines[line.mode.id].append(line)
+        return mode_transit_lines
+
+    def _line_data_to_matrix(self, transit_lines: list, attribute: str,
+                             orig_mapping: Dict[str, int],
+                             dest_mapping: Dict[str, int]) -> numpy.ndarray:
+        """Create inf matrix and insert attribute values into origin and
+        destination indices of the matrix. OD pairs without trade route will 
+        retain their inf attribute value.
+.
+        Parameters
+        ----------
+        transit_lines : list[Transit line]
+            Emme transit line objects
         attribute : str
             Name of attribute
         orig_mapping : dict
@@ -226,8 +258,6 @@ class FreightAssignmentPeriod(AssignmentPeriod):
                 Border id (FIHEL/SESTO...)
             value : int
                 Index number (0, 1, 2, ...)
-        is_export : bool
-            Whether data should be fetched for export (True) or import (False)
 
         Returns
         -------
@@ -237,11 +267,9 @@ class FreightAssignmentPeriod(AssignmentPeriod):
         attr = attribute.replace("ut", "data")
         impedance_matrix = numpy.full(
             (len(orig_mapping), len(dest_mapping)), numpy.inf, dtype="float32")
-        for line in self.emme_scenario.get_network().transit_lines():
-            starts_in_fi = line.id[0:2] == "FI"
-            if (line.mode.id == ship_mode
-                and ((starts_in_fi and is_export)
-                     or (not starts_in_fi and not is_export))):
-                o, d = line.id.split("_")[0].split("-")
+        for line in transit_lines:
+            # Marine transit line id in format port-port_shiptype
+            o, d = str(line).split("_")[0].split("-")
+            if o in orig_mapping and d in dest_mapping:
                 impedance_matrix[orig_mapping[o], dest_mapping[d]] = line[attr]
         return impedance_matrix


### PR DESCRIPTION
Fix bad implementation where marine transit lines were fetched and processed from emme api multiple times during reading impedance information. Now they're read and processed once.