### PR TITLE
Raise error if long dist demand is called before it is calculated

### DIFF
--- a/Scripts/validate_inputfiles.py
+++ b/Scripts/validate_inputfiles.py
@@ -222,9 +222,9 @@ def main(args):
                 Path(args.results_path, name, "Matrices", "koko_suomi"))
     model_types = (args.model_types if args.model_types
                    else ["passenger_transport" for _ in forecast_zonedata_paths])
-    for model_type, data_path, submodel, long_dist_forecast, freight_path in zip(
+    for i, (model_type, data_path, submodel, long_dist_forecast, freight_path) in enumerate(zip(
             model_types, forecast_zonedata_paths, args.submodel,
-            args.long_dist_demand_forecast, args.freight_matrix_paths):
+            args.long_dist_demand_forecast, args.freight_matrix_paths)):
         # Check forecasted zonedata
         if not os.path.exists(data_path):
             msg = "Forecast data file '{}' does not exist.".format(
@@ -241,14 +241,15 @@ def main(args):
             long_dist_classes = (param.car_classes
                                  + param.long_dist_simple_classes)
             long_dist_path = Path(long_dist_forecast)
-            if long_dist_path not in long_dist_result_paths:
+            # Do not iterrupt if long distance run is set to be done now
+            # However long dist path must appear before it is used as base data
+            if long_dist_path not in long_dist_result_paths[:i]:
                 long_dist_matrices = MatrixData(long_dist_path)
                 with long_dist_matrices.open(
                         "demand", "vrk", zone_numbers[submodel],
                         forecast_zonedata.mapping, long_dist_classes) as mtx:
                     for ass_class in long_dist_classes:
                         a = mtx[ass_class]
-
         # Check freight matrices
         if freight_path != "none":
             freight_matrices = MatrixData(Path(freight_path))


### PR DESCRIPTION
If daily and long dist demand forecasts are done same time, but in non expected order, the check for `demand_vrk.omx` does not work and error will happen only after 5-6 hours. So check that long dist model run is calculated before it is used as input data.