### PR TITLE
Change assignment class of home-based business tours

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -292,10 +292,11 @@ class TourPurpose(Purpose):
             if mode not in self.demand_share:
                 self.demand_share[mode] = self.impedance_share[mode]
         self.modes = list(self.model.mode_choice_param)
+        self.intermodals = {key: intermodals[key] for key in self.modes if key in intermodals}
         self.connection_models: Dict[str, logit.LogitModel] = {}
         if "access_mode_choice" in specification:
-            for mode in intermodals:
-                self.modes += intermodals[mode]
+            for mode in self.intermodals:
+                self.modes += self.intermodals[mode]
                 new_spec = copy(specification)
                 new_spec["mode_choice"] = new_spec["access_mode_choice"][mode]
                 self.connection_models[mode] = logit.LogitModel(
@@ -401,7 +402,7 @@ class TourPurpose(Purpose):
             with matrixdata.open(
                     f"logsum_{self.name}", "vrk", list(self.orig_zone_numbers), m='w'
                     ) as mtx:
-                for main_mode, acc_modes in intermodals.items():
+                for main_mode, acc_modes in self.intermodals.items():
                     mode_impedance = {mode: purpose_impedance.pop(mode)
                         for mode in [main_mode] + acc_modes}
                     acc_splits[main_mode], logsum = self.split_connection_mode(

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -472,6 +472,7 @@ simple_transport_classes = (private_classes
 transport_classes = simple_transport_classes + mixed_mode_classes
 intermodals = {
     "transit_leisure": ["pt_car_acc", "pt_taxi_acc", "pt_taxi_egr"],
+    "transit_work": ["pt_car_acc", "pt_taxi_acc", "pt_taxi_egr"],
     "airplane": ["airpl_car_acc", "airpl_car_egr"],
 }
 assignment_classes = {
@@ -485,7 +486,7 @@ assignment_classes = {
     "hb_sport": "leisure",
     "hb_visit": "leisure",
     "hb_leisure_overnight": "leisure",
-    "hb_business": "leisure",
+    "hb_business": "work",
     "wb_business": "work",
     "wb_other": "leisure",
     "ob_other": "leisure",

--- a/Scripts/parameters/cost.py
+++ b/Scripts/parameters/cost.py
@@ -90,12 +90,12 @@ vot = {
         "airpl_car_acc": 11.4,
         "airpl_taxi_acc": 11.4,
         "airpl_car_egr": 11.4,
-        "transit_leisure": 7.7,
+        "transit_work": 7.7,
         "pt_car_acc": 7.7,
         "pt_taxi_acc": 7.7,
         "pt_car_egr": 7.7,
         "pt_taxi_egr": 7.7,
-        "car_leisure": 11.4,
+        "car_work": 11.4,
         "car_pax": 11.4,
     }
 }

--- a/Scripts/parameters/demand/hb_business.json
+++ b/Scripts/parameters/demand/hb_business.json
@@ -29,7 +29,7 @@
                 1.0
               ]
             },
-        "car_leisure": {
+        "car_work": {
             "vrk": [
                 1.0,
                 1.0
@@ -47,7 +47,7 @@
                 1.0
               ]
             },
-        "transit_leisure": {
+        "transit_work": {
             "vrk": [
                 1.0,
                 1.0
@@ -89,7 +89,7 @@
             0,
             30
         ],
-        "car_leisure": [
+        "car_work": [
             0,
             9999
         ],
@@ -113,7 +113,7 @@
             0,
             9999
         ],
-        "transit_leisure": [
+        "transit_work": [
             0,
             9999
         ],
@@ -144,7 +144,7 @@
         }
     },
     "mode_choice": {
-        "car_leisure": {
+        "car_work": {
             "constant": -8.378,
             "generation": {},
             "transform": {
@@ -191,7 +191,7 @@
                 "sh_cars2_hh2": 0.9903
             }
         },
-        "transit_leisure": {
+        "transit_work": {
             "constant": -6.853,
             "generation": {},
             "attraction": {
@@ -228,13 +228,13 @@
             "individual_dummy": {}
         },
         "calibration": {
-            "car_leisure": {
+            "car_work": {
                 "constant": -0.038
             },
             "car_pax": {
                 "constant": 0.138
             },
-            "transit_leisure": {
+            "transit_work": {
                 "constant": 0.040
             },
             "airplane": {
@@ -327,8 +327,8 @@
                 "individual_dummy": {}
             }
         },
-        "transit_leisure": {
-            "transit_leisure": {
+        "transit_work": {
+            "transit_work": {
                 "constant": 0,
                 "generation": {},
                 "attraction": {},
@@ -416,7 +416,7 @@
                 1.0
               ]
         },
-        "car_leisure": {
+        "car_work": {
             "vrk": [
                 1.0,
                 1.0
@@ -434,7 +434,7 @@
                 1.0
               ]
         },
-        "transit_leisure": {
+        "transit_work": {
             "vrk": [
                 1.0,
                 1.0

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -76,8 +76,8 @@ class ModelTest(unittest.TestCase):
 
         # Check that model result does not change
         self.assertAlmostEquals(
-            model.mode_share[0]["car_leisure"],
-            0.636514822974174)
+            model.mode_share[0]["car_work"] + model.mode_share[0]["car_leisure"],
+            0.6362261891983951)
 
     def _validate_impedances(self, impedances):
         self.assertIsNotNone(impedances)


### PR DESCRIPTION
Assignment class should be work. However, this does not fix the problem that all access and egress demand is assigned with "work" value-of-time. This probably cannot be fixed without increasing number of assignments.