### PR TITLE
Remove Excel export of aggregated matrices

### DIFF
--- a/Scripts/Pipfile
+++ b/Scripts/Pipfile
@@ -11,7 +11,6 @@ rope = "*"
 [packages]
 fiona = "==1.9.4.post1"
 pandas = "==2.0.2"
-openpyxl = "*"
 openmatrix = "==0.3.5"
 numpy = "==1.26.2"
 numexpr = "==2.8.4"

--- a/Scripts/Pipfile.lock
+++ b/Scripts/Pipfile.lock
@@ -355,15 +355,6 @@
             "index": "pypi",
             "version": "==0.3.5.0"
         },
-        "openpyxl": {
-            "hashes": [
-                "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2",
-                "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==3.1.5"
-        },
         "packaging": {
             "hashes": [
                 "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",

--- a/Scripts/datahandling/resultdata.py
+++ b/Scripts/datahandling/resultdata.py
@@ -20,7 +20,6 @@ class ResultsData:
         self.path.mkdir(parents=True, exist_ok=True)
         self._line_buffer: Dict[str, Any] = {}
         self._df_buffer: Dict[str, Any] = {}
-        self._xlsx_buffer: Dict[str, Any] = {}
 
     def flush(self):
         """Save to files and empty buffers."""
@@ -32,9 +31,6 @@ class ResultsData:
                 self.path / filename, sep='\t', float_format="%1.5f",
                 header=True)
         self._df_buffer = {}
-        for filename in self._xlsx_buffer:
-            self._xlsx_buffer[filename].close()
-        self._xlsx_buffer = {}
 
     def print_data(self,
                    data: Union[pandas.Series, pandas.DataFrame],
@@ -106,20 +102,6 @@ class ResultsData:
         description : str
             Description of data
         """
-        try:
-            # Get/create new workbook
-            if filename not in self._xlsx_buffer:
-                self._xlsx_buffer[filename] = pandas.ExcelWriter(
-                    self.path / f"{filename}.xlsx")
-        except ModuleNotFoundError:
-            # Do not save data if no openpyxl package available
-            pass
-        else:
-            for key, df in data.items():
-                df.to_excel(
-                    self._xlsx_buffer[filename],
-                    sheet_name=f"{description}_{key}")
-        # Create text file
         stacked_matrices = pandas.concat(
              {(description, key): df.stack() for key, df in data.items()},
             names=["purpose", "mode", "orig", "dest"])

--- a/Scripts/parameters/validate.py
+++ b/Scripts/parameters/validate.py
@@ -1,6 +1,0 @@
-
-peak_shares = {
-    "Turku": {
-        "walk":
-    }
-}

--- a/Scripts/parameters/validate.py
+++ b/Scripts/parameters/validate.py
@@ -1,0 +1,6 @@
+
+peak_shares = {
+    "Turku": {
+        "walk":
+    }
+}

--- a/Scripts/requirements.txt
+++ b/Scripts/requirements.txt
@@ -1,2 +1,0 @@
-openpyxl==2.6.4;python_version<"3.8"
-openpyxl==3.1.4;python_version>="3.8"


### PR DESCRIPTION
* There is dependency problem with `openpyxl` package. Package is now used only to print aggregated demand matrices. 
* Current format of matrices work well with Pivot Table, so direct Excel export can be deprecated. 
* Remove `openpyxl` from pipfile and requirements.txt, but keep requirements file as we might need it later.