### PR TITLE
Add mode name to assignment class lookup tables

### DIFF
--- a/Scripts/assignment/departure_time.py
+++ b/Scripts/assignment/departure_time.py
@@ -6,7 +6,11 @@ from datatypes.demand import Demand
 import utils.log as log
 from assignment.abstract_assignment import AssignmentModel, Period
 import parameters.departure_time as param
-from parameters.assignment import transport_classes, volume_factors, asymmetric_demand
+from parameters.assignment import (
+    transport_classes, 
+    volume_factors, 
+    mode_assignment_classes
+)
 
 
 class DepartureTimeModel:
@@ -90,31 +94,21 @@ class DepartureTimeModel:
             Travel demand matrix or number of travellers
         """
         position: Sequence[int] = demand.position
-        if demand.mode == "car_drv":
-            ass_class = "car"
-        else: 
-            ass_class = demand.mode
-        if len(position) == 2:
-            share: Dict[str, Any] = demand.purpose.demand_share[demand.mode]
-            for ap in self.assignment_periods:
-                if ass_class in ap.assignment_modes:
-                    self._add_2d_demand(
-                        share[ap.name], ass_class, ap.name,
-                        demand.matrix, position)
-            if ass_class in asymmetric_demand:
-                mode = asymmetric_demand[ass_class]
-                share: Dict[str, Any] = demand.purpose.demand_share[mode]
+        ass_classes = mode_assignment_classes[demand.mode]
+        for ass_class in ass_classes:
+            if len(position) == 2:
+                share: Dict[str, Any] = demand.purpose.demand_share[demand.mode]
                 for ap in self.assignment_periods:
                     if ass_class in ap.assignment_modes:
                         self._add_2d_demand(
-                            share[ap.name], mode, ap.name,
+                            share[ap.name], ass_class, ap.name,
                             demand.matrix, position)
-        elif len(position) == 3:
-            for ap in self.assignment_periods:
-                if ass_class in ap.assignment_modes:
-                    self._add_3d_demand(demand, demand.mode, ap.name)
-        else:
-            raise IndexError("Tuple position has wrong dimensions.")
+            elif len(position) == 3:
+                for ap in self.assignment_periods:
+                    if ass_class in ap.assignment_modes:
+                        self._add_3d_demand(demand, ass_class, ap.name)
+            else:
+                raise IndexError("Tuple position has wrong dimensions.")
 
     def _add_2d_demand(self,
                        demand_share: Any,

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -13,7 +13,9 @@ import models.logit as logit
 from parameters.assignment import (
     assignment_classes,
     intermodals,
-    mixed_mode_classes)
+    mixed_mode_classes,
+    mode_impedance
+)
 import parameters.cost as cost
 import models.generation as generation
 from datatypes.demand import Demand
@@ -122,10 +124,7 @@ class Purpose:
         day_imp = defaultdict(lambda: defaultdict(float))
         for mode in self.impedance_share:
             share_sum = 0
-            if mode in ["car_drv", "car_pax"]:
-                ass_class = "car"
-            else:
-                ass_class = mode
+            ass_class = mode_impedance[mode]
             for time_period in self.impedance_share[mode]:
                 for mtx_type in impedance[time_period]:
                     if ass_class in impedance[time_period][mtx_type]:

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -377,15 +377,6 @@ effective_headway_ld = {
 }
 
 ### ASSIGNMENT REFERENCES ###
-asymmetric_demand = {
-    "pt_car_acc": "pt_car_egr",
-    "pt_taxi_acc": "pt_taxi_egr",
-    "airpl_car_acc": "airpl_car_egr",
-    "pt_car_egr": "pt_car_acc",
-    "pt_taxi_egr": "pt_taxi_acc",
-    "airpl_car_egr": "airpl_car_acc"
-}
-
 time_periods = {
     "aht": "AssignmentPeriod",
     "pt": "OffPeakPeriod",
@@ -599,4 +590,36 @@ roadtypes = {
     5: "single-lane",
     11: "ferry",
     99: "connector",
+}
+# modes in choice model : impedance
+mode_impedance = {
+    "car_drv": "car", 
+    "car_pax": "car",
+    "transit": "transit",
+    "airplane": "airplane",
+    "bike": "bike",
+    "walk": "walk",
+    "pt_car_acc": "pt_car_acc",
+    "pt_taxi_acc": "pt_taxi_acc",
+    "airpl_car_acc": "airpl_car_acc",
+    "pt_car_egr": "pt_car_egr",
+    "pt_taxi_egr": "pt_taxi_egr",
+    "airpl_car_egr": "airpl_car_egr"
+
+}
+# modes in choice model : [assignment classes]
+mode_assignment_classes = {
+    "car_drv": ["car"], 
+    "car_pax": [],
+    "car": ["car"],
+    "transit": ["transit"],
+    "airplane": ["airplane"],
+    "bike": ["bike"],
+    "walk": ["walk"],
+    "pt_car_acc": ["pt_car_acc", "pt_car_egr"],
+    "pt_taxi_acc": ["pt_taxi_acc", "pt_taxi_egr"],
+    "airpl_car_acc": ["airpl_car_acc", "airpl_car_egr"],
+    "pt_car_egr": ["pt_car_egr", "pt_car_acc"],
+    "pt_taxi_egr": ["pt_taxi_egr", "pt_taxi_acc"],
+    "airpl_car_egr": ["airpl_car_egr", "airpl_car_acc"]
 }

--- a/Scripts/tests/unit/test_departure_time.py
+++ b/Scripts/tests/unit/test_departure_time.py
@@ -30,7 +30,7 @@ class DepartureTimeTest(unittest.TestCase):
 
         dem.purpose.name = "wb_other"
         dem.purpose.demand_share = {
-            "car": {
+            "car_drv": {
                 "aht":[
                     [0.0113538534294527, 0.0483356330299955],
                     [0.000783876140666748, 0.0782437896466509]
@@ -63,7 +63,7 @@ class DepartureTimeTest(unittest.TestCase):
                 ],
             },
         }
-        dem.mode = "car"
+        dem.mode = "car_drv"
         dem.matrix = mtx
         dem.orig = 1
         dem.dest = None

--- a/Scripts/travel_iteration.py
+++ b/Scripts/travel_iteration.py
@@ -160,11 +160,8 @@ class ModelSystem:
         self.travel_modes = {mode: True for purpose in self.dm.tour_purposes
             for mode in purpose.modes}  # Dict instead of set, to preserve order
         self.ass_classes = set()
-        for key in self.travel_modes.keys():
-            if key in ["car_drv", "car_pax"]:
-                self.ass_classes.add("car")
-            else: 
-                self.ass_classes.add(key)
+        for mode in self.travel_modes.keys():
+            self.ass_classes.add(param.mode_impedance[mode])
         self.external_purpose = ExternalPurpose(numpy.array(self.zone_numbers))
         self.mode_share: List[Dict[str,Any]] = []
         self.convergence = []


### PR DESCRIPTION
* Attempt to clarify transformations between choice model mode names and assignment classes. 
* Use lookup table in place of hard coded mode name transformations.