### PR TITLE
Adjust long distance train in-vehicle time

### DIFF
--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -164,7 +164,7 @@ freight_terminal_cost = {
     'W': 0
 }
 in_vehicle_weight = {
-    'j': 0.6,
+    'j': 0.8,
 }
 # Boarding penalties for different transit modes
 boarding_penalty = {


### PR DESCRIPTION
Change in_vehicle_weight for mode long distance trains from 0.6 to 0.8.

Based on the testing with 2025 traffic network and 2025 public transport costs, the previous value 0.6 overshoots the train passenger amounts on the major train lines. Further calibration is needed after the re-estimation of the model.