### PR TITLE
Guard null submodels in zonedata.py

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -319,6 +319,8 @@ class ZoneData:
         mapping = self.demand_aggs.mappings["submodel"]
         submodels = mapping.drop_duplicates()
         for submodel in submodels:
+            if submodel is None:
+                continue
             if self.mapping.name == submodel.lower().replace('-', '_'):
                 return mapping == submodel
         else:


### PR DESCRIPTION
Fixes a possible fatal error if zonedata.gpkg contains NULL values in 'submodel' -column