### PR TITLE
Force trucks to pass through designated leg2 border pairs

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -774,6 +774,20 @@ class FreightPurpose(Purpose):
             self.costdata, ship_imps, self.model_category, fin_border_ids,
             self.is_export)
         impedance_legs["leg_two"].update(ship_costs)
+
+        # Retain leg two truck cost only for designated border pairs
+        mask = numpy.ones(impedance_legs["leg_two"]["truck"]["cost"].shape, dtype=bool)
+        fin_indices = {key: idx for idx, key in enumerate(fin_border_ids)}
+        foreign_indices = {key: idx for idx, key in enumerate(cluster_border_ids)}
+        for border_pair in param.land_border_pairs.values():
+            if (border_pair["finland_border"] in fin_border_ids 
+            and border_pair["foreign_border"] in cluster_border_ids):
+                fin_index = fin_indices[border_pair["finland_border"]]
+                foreign_index = foreign_indices[border_pair["foreign_border"]]
+                row = fin_index if self.is_export else foreign_index
+                col = foreign_index if self.is_export else fin_index
+                mask[row, col] = False
+        impedance_legs["leg_two"]["truck"]["cost"][mask] = numpy.inf
         return impedance_legs
 
     def get_costs(self, impedance: dict):

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -775,17 +775,14 @@ class FreightPurpose(Purpose):
             self.is_export)
         impedance_legs["leg_two"].update(ship_costs)
 
-        # Retain leg two truck cost only for designated border pairs
-        pairs = numpy.array(list(param.land_border_pairs.values()))
-        exists = pairs[numpy.isin(pairs[:, 0], fin_port_zones) 
-                       & numpy.isin(pairs[:, 1], cluster_port_zones)]
-        fin_idx = numpy.searchsorted(fin_port_zones, exists[:, 0])
-        cluster_idx = numpy.searchsorted(cluster_port_zones, exists[:, 1])
-        mask = numpy.ones(impedance_legs["leg_two"]["truck"]["cost"].shape, dtype=bool)
-        rows = fin_idx if self.is_export else cluster_idx
-        cols = cluster_idx if self.is_export else fin_idx
-        mask[rows, cols] = False
-        impedance_legs["leg_two"]["truck"]["cost"][mask] = numpy.inf
+        # Retain leg two truck cost only for designated land border pairs
+        mask = pandas.DataFrame(True, index=fin_port_zones, columns=cluster_port_zones)
+        for fin_border, cluster_border in param.land_border_pairs.values():
+            if fin_border in fin_port_zones and cluster_border in cluster_port_zones:
+                mask.at[fin_border, cluster_border] = False
+        if not self.is_export:
+            mask = mask.T
+        impedance_legs["leg_two"]["truck"]["cost"][mask.to_numpy()] = numpy.inf
         return impedance_legs
 
     def get_costs(self, impedance: dict):

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -776,17 +776,15 @@ class FreightPurpose(Purpose):
         impedance_legs["leg_two"].update(ship_costs)
 
         # Retain leg two truck cost only for designated border pairs
+        pairs = numpy.array(list(param.land_border_pairs.values()))
+        exists = pairs[numpy.isin(pairs[:, 0], fin_port_zones) 
+                       & numpy.isin(pairs[:, 1], cluster_port_zones)]
+        fin_idx = numpy.searchsorted(fin_port_zones, exists[:, 0])
+        cluster_idx = numpy.searchsorted(cluster_port_zones, exists[:, 1])
         mask = numpy.ones(impedance_legs["leg_two"]["truck"]["cost"].shape, dtype=bool)
-        fin_indices = {key: idx for idx, key in enumerate(fin_border_ids)}
-        foreign_indices = {key: idx for idx, key in enumerate(cluster_border_ids)}
-        for border_pair in param.land_border_pairs.values():
-            if (border_pair["finland_border"] in fin_border_ids 
-            and border_pair["foreign_border"] in cluster_border_ids):
-                fin_index = fin_indices[border_pair["finland_border"]]
-                foreign_index = foreign_indices[border_pair["foreign_border"]]
-                row = fin_index if self.is_export else foreign_index
-                col = foreign_index if self.is_export else fin_index
-                mask[row, col] = False
+        rows = fin_idx if self.is_export else cluster_idx
+        cols = cluster_idx if self.is_export else fin_idx
+        mask[rows, cols] = False
         impedance_legs["leg_two"]["truck"]["cost"][mask] = numpy.inf
         return impedance_legs
 

--- a/Scripts/parameters/zone.py
+++ b/Scripts/parameters/zone.py
@@ -14,7 +14,7 @@ purpose_areas: Dict[str, Tuple[int,int]] = {
 tour_length_intervals = (0, 3, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100,
                          200, 300, 400, 500, 600, 700, 800, float("inf"))
 
-# Finnish ports and road border control points
+# Finnish ports and land border control points
 finland_border_points = {
     "FIHEL": {"name": "Vuosaari", "id": 524},
     "FISKV": {"name": "Skoljdvik", "id": 3607},
@@ -44,7 +44,7 @@ finland_border_points = {
     "FIKJO": {"name": "Kalajoki", "id": 34611},
 }
 
-# Clusters of foreign ports and border control points
+# cluster ports and land border control points
 cluster_border_points = {
     "AEJEA": {"name": "Jebel Ali", "id": 50100},
     "BRITQ": {"name": "Itaqui", "id": 50101},
@@ -77,4 +77,12 @@ cluster_border_points = {
     "SGJUR": {"name": "Singapore", "id": 50128},
     "TRIST": {"name": "Istanbul", "id": 50129},
     "USHOU": {"name": "Houston", "id": 50130},
+}
+
+land_border_pairs = {
+    "Vainikkala": {"finland_border": "FIVAI", "foreign_border": "RUVAI"},
+    "Vaalimaa": {"finland_border": "FIVAL", "foreign_border": "RUVAL"},
+    "Vartius": {"finland_border": "FIVAR", "foreign_border": "RUVAR"},
+    "Tornio": {"finland_border": "FITOR", "foreign_border": "SEHAA"},
+    "Kilpisjärvi": {"finland_border": "FIKIL", "foreign_border": "NOKIL"},
 }

--- a/Scripts/parameters/zone.py
+++ b/Scripts/parameters/zone.py
@@ -79,10 +79,11 @@ cluster_border_points = {
     "USHOU": {"name": "Houston", "id": 50130},
 }
 
+# Finnish land border centroid and its foreign counterpart
 land_border_pairs = {
-    "Vainikkala": {"finland_border": "FIVAI", "foreign_border": "RUVAI"},
-    "Vaalimaa": {"finland_border": "FIVAL", "foreign_border": "RUVAL"},
-    "Vartius": {"finland_border": "FIVAR", "foreign_border": "RUVAR"},
-    "Tornio": {"finland_border": "FITOR", "foreign_border": "SEHAA"},
-    "Kilpisjärvi": {"finland_border": "FIKIL", "foreign_border": "NOKIL"},
+    "Vainikkala": [15106, 50120],
+    "Vaalimaa": [19705, 50122],
+    "Vartius": [26946, 50121],
+    "Tornio": [28615, 50124],
+    "Kilpisjarvi": [30219, 50117]
 }

--- a/Scripts/tests/unit/test_trade_route_choice.py
+++ b/Scripts/tests/unit/test_trade_route_choice.py
@@ -111,18 +111,18 @@ class TradeRouteChoiceTest(unittest.TestCase):
         self.assertEqual(len(leg_two), 3)
         self.assertEqual(len(leg_three), 1)
         if name == "kemlaa_export":
-            truck_leg1_cols = numpy.array((8.169347, 14.315129), dtype=numpy.float32)
+            truck_leg1_cols = numpy.array((6.469845, 16.014631), dtype=numpy.float32)
             self.assertAlmostEqual(numpy.sum(leg_one["truck"]), 22.484474, places=3)
             numpy.testing.assert_array_almost_equal(
                 numpy.sum(leg_one["truck"], axis=0), truck_leg1_cols)
 
-            truck_leg2_cols = numpy.array((4.003486, 4.003484), dtype=numpy.float32)
-            truck_leg2_row = numpy.array((4.0034847, 4.0034847), dtype=numpy.float32)
-            container_leg2_cols = numpy.array((0, 10.3116455), dtype=numpy.float32)
-            roro_leg2_cols = numpy.array((4.1658616, 0), dtype=numpy.float32)
-            self.assertAlmostEqual(numpy.sum(leg_two["truck"]), 8.006969, places=3)
-            self.assertAlmostEqual(numpy.sum(leg_two["container_ship"]), 10.3116455, places=3)
-            self.assertAlmostEqual(numpy.sum(leg_two["roro_vessel"]), 4.1658616, places=3)
+            truck_leg2_cols = numpy.array((0.0, 0.0), dtype=numpy.float32)
+            truck_leg2_row = numpy.array((0.0, 0.0), dtype=numpy.float32)
+            container_leg2_cols = numpy.array((0, 16.014631), dtype=numpy.float32)
+            roro_leg2_cols = numpy.array((6.4698453, 0), dtype=numpy.float32)
+            self.assertAlmostEqual(numpy.sum(leg_two["truck"]), 0.0)
+            self.assertAlmostEqual(numpy.sum(leg_two["container_ship"]), 16.014631, places=3)
+            self.assertAlmostEqual(numpy.sum(leg_two["roro_vessel"]), 6.4698453, places=3)
             numpy.testing.assert_array_almost_equal(
                 numpy.sum(leg_two["truck"], axis=0), truck_leg2_cols)
             numpy.testing.assert_array_almost_equal(
@@ -138,18 +138,18 @@ class TradeRouteChoiceTest(unittest.TestCase):
                 numpy.sum(leg_three["truck"], axis=0), truck_leg3_cols)
             
         elif name == "kemlaa_import":
-            truck_leg1_row = numpy.array((203.28798, 231.84685), dtype=numpy.float32)
+            truck_leg1_row = numpy.array((203.28798, 231.84686), dtype=numpy.float32)
             self.assertAlmostEqual(numpy.sum(leg_one["truck"]), 435.13483, places=3)
             numpy.testing.assert_array_almost_equal(
                 numpy.sum(leg_one["truck"], axis=1), truck_leg1_row)
 
-            truck_leg2_cols = numpy.array((34.18222, 32.160725), dtype=numpy.float32)
-            truck_leg2_row = numpy.array((33.581642, 32.761303), dtype=numpy.float32)
-            container_leg2_row = numpy.array((0, 61.939617), dtype=numpy.float32)
-            roro_leg2_row = numpy.array((306.85233, 0), dtype=numpy.float32)
-            self.assertAlmostEqual(numpy.sum(leg_two["truck"]), 66.34295, places=3)
-            self.assertAlmostEqual(numpy.sum(leg_two["container_ship"]), 61.939617, places=3)
-            self.assertAlmostEqual(numpy.sum(leg_two["roro_vessel"]), 306.85233, places=3)
+            truck_leg2_cols = numpy.array((0.0, 0.0), dtype=numpy.float32)
+            truck_leg2_row = numpy.array((0.0, 0.0), dtype=numpy.float32)
+            container_leg2_row = numpy.array((0, 81.80068), dtype=numpy.float32)
+            roro_leg2_row = numpy.array((353.33417, 0), dtype=numpy.float32)
+            self.assertAlmostEqual(numpy.sum(leg_two["truck"]), 0.0)
+            self.assertAlmostEqual(numpy.sum(leg_two["container_ship"]), 81.80068, places=3)
+            self.assertAlmostEqual(numpy.sum(leg_two["roro_vessel"]), 353.33417, places=3)
             numpy.testing.assert_array_almost_equal(
                 numpy.sum(leg_two["truck"], axis=0), truck_leg2_cols)
             numpy.testing.assert_array_almost_equal(
@@ -159,7 +159,7 @@ class TradeRouteChoiceTest(unittest.TestCase):
             numpy.testing.assert_array_almost_equal(
                 numpy.sum(leg_two["roro_vessel"], axis=1), roro_leg2_row)
             
-            truck_leg3_cols = numpy.array((341.03445, 94.10034), dtype=numpy.float32)
+            truck_leg3_cols = numpy.array((353.33414, 81.80069), dtype=numpy.float32)
             self.assertAlmostEqual(numpy.sum(leg_three["truck"]), 435.13483, places=3)
             numpy.testing.assert_array_almost_equal(
                 numpy.sum(leg_three["truck"], axis=1), truck_leg3_cols)


### PR DESCRIPTION
Current impedance design allows trucks on second leg to incorrectly route from/to ports and between incorrect border pairs. Instead in second leg trucks are only allowed to route through specific land border control pairs.