### PR TITLE
calc trade domestic leg share

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -846,23 +846,24 @@ class FreightPurpose(Purpose):
                      where=demand_sum > 0.0)
         train_share = numpy.ones_like(truck_share) - truck_share
         
-        purpose_trade_demand = {k: v for k, v in trade_demand.items()
-                                if k.split('_')[0] == self.name}
+        purpose_trade_demand = {
+            k: v for k, v in trade_demand.items()
+            if k.startswith(f"{self.name}_")
+        }
         fin_borders = numpy.array(list(fin_borders.values()), dtype=numpy.int32)
         mask = numpy.isin(self.orig_zone_numbers, fin_borders)
-        dom_leg_demand = {
-            purpose: {mode: numpy.zeros_like(truck_share)
-                      for mode in ["truck", "freight_train"]} 
-            for purpose in purpose_trade_demand
-        }
+        
+        dom_leg_demand = {}
         for purpose in purpose_trade_demand:
             demand_full = numpy.zeros_like(truck_share)
-            if purpose.split("_")[1] == "export":
+            if purpose.endswith("_export"):
                 demand_full[:, mask] = purpose_trade_demand[purpose]["leg_one"]["truck"]
             else:
                 demand_full[mask, :] = purpose_trade_demand[purpose]["leg_three"]["truck"]
-            dom_leg_demand[purpose]["truck"] += demand_full * truck_share
-            dom_leg_demand[purpose]["freight_train"] += demand_full * train_share
+            dom_leg_demand[purpose] = {"truck": demand_full * truck_share}
+            train_share = demand_full * train_share
+            if numpy.sum(train_share) > 0.0:
+                dom_leg_demand[purpose].update({"freight_train": train_share})
         return dom_leg_demand
 
     def run_logistics_module(self, demand_truck: numpy.ndarray, impedance: numpy.ndarray, 

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -826,7 +826,7 @@ class FreightPurpose(Purpose):
         demand : dict
             Mode (truck/train/...) : calculated demand (numpy 2d matrix)
         trade_demand : dict
-            Purpose name (elektr_export/elektr_import...) : Leg
+            Foreign FreightPurpose : Leg
                 Name (one/two/three) : Mode
                     Name (truck/container_ship...) : numpy 2d array
         fin_borders : dict
@@ -836,27 +836,31 @@ class FreightPurpose(Purpose):
         Returns
         -------
         dict
-            mode (truck/freight_train) : tons on domestic leg
+            Foreign FreightPurpose : Mode
+                Name (truck/freight_train) : tons on domestic leg
         """
         demand_sum = sum(demand[mode] for mode in demand
                          if mode in ["truck", "freight_train"])
-        truck_share = numpy.divide(demand["truck"], demand_sum,
-                                   where=demand_sum > 0)
+        truck_share = numpy.zeros_like(demand_sum)
+        numpy.divide(demand["truck"], demand_sum, out=truck_share,
+                     where=demand_sum > 0.0)
         train_share = numpy.ones_like(truck_share) - truck_share
+        
         purpose_trade_demand = {k: v for k, v in trade_demand.items()
-                                if k.split('_')[0] == self.name}
+                                if k.name.split('_')[0] == self.name}
         fin_borders = numpy.array(list(fin_borders.values()), dtype=numpy.int32)
         fin_borders = numpy.isin(self.orig_zone_numbers, fin_borders)
-        mode_demand = {k: numpy.zeros_like(truck_share)
-                       for k in ("truck", "freight_train")}
+        mode_demand = {}
         for purpose in purpose_trade_demand:
-            trade_demand = numpy.zeros_like(truck_share)
-            if purpose.split("_")[1] == "export":
-                trade_demand[:, fin_borders] = purpose_trade_demand[purpose]["leg_one"]["truck"]
+            demand_full = numpy.zeros_like(truck_share)
+            if purpose.is_export:
+                demand_full[:, fin_borders] = purpose_trade_demand[purpose]["leg_one"]["truck"]
             else:
-                trade_demand[fin_borders, :] = purpose_trade_demand[purpose]["leg_three"]["truck"]
-            mode_demand["truck"] += trade_demand * truck_share
-            mode_demand["freight_train"] += trade_demand * train_share
+                demand_full[fin_borders, :] = purpose_trade_demand[purpose]["leg_three"]["truck"]
+            mode_demand[purpose] = {"truck": demand_full * truck_share}
+            train_demand = demand_full * train_share
+            if numpy.sum(train_demand) > 0.0:
+                mode_demand[purpose].update({"freight_train": train_demand})
         return mode_demand
 
     def run_logistics_module(self, demand_truck: numpy.ndarray, impedance: numpy.ndarray, 
@@ -930,18 +934,9 @@ class FreightPurpose(Purpose):
 
         mapping_name = (self.generation_zone_data.mapping.name if self.is_export 
                         else self.attraction_zone_data.mapping.name)
-        all_zones = self.generation_zone_data.all_zone_numbers
         if mapping_name == "municipality_center":
             df = pandas.DataFrame(demand, trade_mappings["finland_zone_number"])
             demand = df.groupby(self.generation_zone_data.mapping).sum().to_numpy()
-        elif demand.shape[0] != self.orig_zone_numbers.size:
-            idx_names = ["finland_zone_number", "cluster_zone_number"]
-            idx = [None, None]
-            for i, name in enumerate(idx_names):
-                mapping_arr = numpy.array(trade_mappings[name], dtype=all_zones.dtype)
-                mask = numpy.isin(all_zones, mapping_arr)
-                idx[i] = numpy.where(mask)[0].astype(numpy.int32)
-            demand = demand[numpy.ix_(idx[0], idx[1])]
         demand = demand.T if not self.is_export else demand
 
         # Finland border control point key - zone index

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -816,19 +816,19 @@ class FreightPurpose(Purpose):
         vehicles += vehicles.T * costdata["empty_share"]
         return vehicles
 
-    def calc_trade_mode_share(self, demand: dict, trade_demand: dict,
+    def calc_trade_mode_share(self, dom_demand: dict, trade_demand: dict,
                               fin_borders: dict):
         """Calculate mode share of trade demand on its domestic leg 
-        between freight land modes.
+        among freight land mode alternatives.
 
         Parameters
         ----------
-        demand : dict
-            Mode (truck/train/...) : calculated demand (numpy 2d matrix)
+        dom_demand : dict
+            Mode (truck/train/...) : domestic demand numpy 2d array
         trade_demand : dict
-            Foreign FreightPurpose : Leg
-                Name (one/two/three) : Mode
-                    Name (truck/container_ship...) : numpy 2d array
+            Foreign purpose name : str
+                Leg (one/two/three) : str
+                    Mode (truck/container_ship...) : trade demand numpy 2d array
         fin_borders : dict
             Finland border id (FIHEL/FISKV...) : str
                 Centroid id : int
@@ -836,32 +836,34 @@ class FreightPurpose(Purpose):
         Returns
         -------
         dict
-            Foreign FreightPurpose : Mode
-                Name (truck/freight_train) : tons on domestic leg
+            Foreign purpose name : str
+                Mode (truck/freight_train) : trade demand domestic leg numpy 2d array
         """
-        demand_sum = sum(demand[mode] for mode in demand
+        demand_sum = sum(dom_demand[mode] for mode in dom_demand
                          if mode in ["truck", "freight_train"])
         truck_share = numpy.zeros_like(demand_sum)
-        numpy.divide(demand["truck"], demand_sum, out=truck_share,
+        numpy.divide(dom_demand["truck"], demand_sum, out=truck_share,
                      where=demand_sum > 0.0)
         train_share = numpy.ones_like(truck_share) - truck_share
         
         purpose_trade_demand = {k: v for k, v in trade_demand.items()
-                                if k.name.split('_')[0] == self.name}
+                                if k.split('_')[0] == self.name}
         fin_borders = numpy.array(list(fin_borders.values()), dtype=numpy.int32)
-        fin_borders = numpy.isin(self.orig_zone_numbers, fin_borders)
-        mode_demand = {}
+        mask = numpy.isin(self.orig_zone_numbers, fin_borders)
+        dom_leg_demand = {
+            purpose: {mode: numpy.zeros_like(truck_share)
+                      for mode in ["truck", "freight_train"]} 
+            for purpose in purpose_trade_demand
+        }
         for purpose in purpose_trade_demand:
             demand_full = numpy.zeros_like(truck_share)
-            if purpose.is_export:
-                demand_full[:, fin_borders] = purpose_trade_demand[purpose]["leg_one"]["truck"]
+            if purpose.split("_")[1] == "export":
+                demand_full[:, mask] = purpose_trade_demand[purpose]["leg_one"]["truck"]
             else:
-                demand_full[fin_borders, :] = purpose_trade_demand[purpose]["leg_three"]["truck"]
-            mode_demand[purpose] = {"truck": demand_full * truck_share}
-            train_demand = demand_full * train_share
-            if numpy.sum(train_demand) > 0.0:
-                mode_demand[purpose].update({"freight_train": train_demand})
-        return mode_demand
+                demand_full[mask, :] = purpose_trade_demand[purpose]["leg_three"]["truck"]
+            dom_leg_demand[purpose]["truck"] += demand_full * truck_share
+            dom_leg_demand[purpose]["freight_train"] += demand_full * train_share
+        return dom_leg_demand
 
     def run_logistics_module(self, demand_truck: numpy.ndarray, impedance: numpy.ndarray, 
                              zone_index_map: dict, iterations: int) -> tuple:

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -818,9 +818,8 @@ class FreightPurpose(Purpose):
 
     def calc_trade_mode_share(self, demand: dict, trade_demand: dict,
                               fin_borders: dict):
-        """Calculate truck mode share for domestic demand. Use the share
-        to calculate how traded demand for self purpose are distributed
-        to truck mode on domestic leg.
+        """Calculate mode share of trade demand on its domestic leg 
+        between freight land modes.
 
         Parameters
         ----------
@@ -836,25 +835,29 @@ class FreightPurpose(Purpose):
 
         Returns
         -------
-        numpy.ndarray
-            truck tons on domestic leg
+        dict
+            mode (truck/freight_train) : tons on domestic leg
         """
-        demand_sum = sum(demand[mode] for mode in demand)
+        demand_sum = sum(demand[mode] for mode in demand
+                         if mode in ["truck", "freight_train"])
         truck_share = numpy.divide(demand["truck"], demand_sum,
                                    where=demand_sum > 0)
+        train_share = numpy.ones_like(truck_share) - truck_share
         purpose_trade_demand = {k: v for k, v in trade_demand.items()
                                 if k.split('_')[0] == self.name}
         fin_borders = numpy.array(list(fin_borders.values()), dtype=numpy.int32)
         fin_borders = numpy.isin(self.orig_zone_numbers, fin_borders)
-        matrices = []
+        mode_demand = {k: numpy.zeros_like(truck_share)
+                       for k in ("truck", "freight_train")}
         for purpose in purpose_trade_demand:
             trade_demand = numpy.zeros_like(truck_share)
             if purpose.split("_")[1] == "export":
                 trade_demand[:, fin_borders] = purpose_trade_demand[purpose]["leg_one"]["truck"]
             else:
                 trade_demand[fin_borders, :] = purpose_trade_demand[purpose]["leg_three"]["truck"]
-            matrices.append(trade_demand * truck_share)
-        return sum(matrix for matrix in matrices)
+            mode_demand["truck"] += trade_demand * truck_share
+            mode_demand["freight_train"] += trade_demand * train_share
+        return mode_demand
 
     def run_logistics_module(self, demand_truck: numpy.ndarray, impedance: numpy.ndarray, 
                              zone_index_map: dict, iterations: int) -> tuple:

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -817,7 +817,7 @@ class FreightPurpose(Purpose):
         return vehicles
 
     def calc_trade_mode_share(self, dom_demand: dict, trade_demand: dict,
-                              fin_borders: dict):
+                              fin_borders: list):
         """Calculate mode share of trade demand on its domestic leg 
         among freight land mode alternatives.
 
@@ -829,9 +829,8 @@ class FreightPurpose(Purpose):
             Foreign purpose name : str
                 Leg (one/two/three) : str
                     Mode (truck/container_ship...) : trade demand numpy 2d array
-        fin_borders : dict
-            Finland border id (FIHEL/FISKV...) : str
-                Centroid id : int
+        fin_borders : list[int]
+            Finnish border centroid ids
 
         Returns
         -------
@@ -846,24 +845,26 @@ class FreightPurpose(Purpose):
                      where=demand_sum > 0.0)
         train_share = numpy.ones_like(truck_share) - truck_share
         
+        # Extracts trade purposes with same name as self.name
+        # e.g. if self is kemlaa, extracts kemlaa_export and kemlaa_import
         purpose_trade_demand = {
             k: v for k, v in trade_demand.items()
             if k.startswith(f"{self.name}_")
         }
-        fin_borders = numpy.array(list(fin_borders.values()), dtype=numpy.int32)
-        mask = numpy.isin(self.orig_zone_numbers, fin_borders)
         
         dom_leg_demand = {}
         for purpose in purpose_trade_demand:
-            demand_full = numpy.zeros_like(truck_share)
+            demand_full = pandas.DataFrame(
+                0, index=self.orig_zone_numbers, columns=self.orig_zone_numbers
+            )
             if purpose.endswith("_export"):
-                demand_full[:, mask] = purpose_trade_demand[purpose]["leg_one"]["truck"]
+                demand_full.loc[:, fin_borders] = purpose_trade_demand[purpose]["leg_one"]["truck"]
             else:
-                demand_full[mask, :] = purpose_trade_demand[purpose]["leg_three"]["truck"]
-            dom_leg_demand[purpose] = {"truck": demand_full * truck_share}
-            train_share = demand_full * train_share
-            if numpy.sum(train_share) > 0.0:
-                dom_leg_demand[purpose].update({"freight_train": train_share})
+                demand_full.loc[fin_borders, :] = purpose_trade_demand[purpose]["leg_three"]["truck"]
+            dom_leg_demand[purpose] = {"truck": demand_full.values * truck_share}
+            train_demand = demand_full.values * train_share
+            if numpy.sum(train_demand) > 0.0:
+                dom_leg_demand[purpose]["freight_train"] = train_demand
         return dom_leg_demand
 
     def run_logistics_module(self, demand_truck: numpy.ndarray, impedance: numpy.ndarray, 

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -816,6 +816,46 @@ class FreightPurpose(Purpose):
         vehicles += vehicles.T * costdata["empty_share"]
         return vehicles
 
+    def calc_trade_mode_share(self, demand: dict, trade_demand: dict,
+                              fin_borders: dict):
+        """Calculate truck mode share for domestic demand. Use the share
+        to calculate how traded demand for self purpose are distributed
+        to truck mode on domestic leg.
+
+        Parameters
+        ----------
+        demand : dict
+            Mode (truck/train/...) : calculated demand (numpy 2d matrix)
+        trade_demand : dict
+            Purpose name (elektr_export/elektr_import...) : Leg
+                Name (one/two/three) : Mode
+                    Name (truck/container_ship...) : numpy 2d array
+        fin_borders : dict
+            Finland border id (FIHEL/FISKV...) : str
+                Centroid id : int
+
+        Returns
+        -------
+        numpy.ndarray
+            truck tons on domestic leg
+        """
+        demand_sum = sum(demand[mode] for mode in demand)
+        truck_share = numpy.divide(demand["truck"], demand_sum,
+                                   where=demand_sum > 0)
+        purpose_trade_demand = {k: v for k, v in trade_demand.items()
+                                if k.split('_')[0] == self.name}
+        fin_borders = numpy.array(list(fin_borders.values()), dtype=numpy.int32)
+        fin_borders = numpy.isin(self.orig_zone_numbers, fin_borders)
+        matrices = []
+        for purpose in purpose_trade_demand:
+            trade_demand = numpy.zeros_like(truck_share)
+            if purpose.split("_")[1] == "export":
+                trade_demand[:, fin_borders] = purpose_trade_demand[purpose]["leg_one"]["truck"]
+            else:
+                trade_demand[fin_borders, :] = purpose_trade_demand[purpose]["leg_three"]["truck"]
+            matrices.append(trade_demand * truck_share)
+        return sum(matrix for matrix in matrices)
+
     def run_logistics_module(self, demand_truck: numpy.ndarray, impedance: numpy.ndarray, 
                              zone_index_map: dict, iterations: int) -> tuple:
         """Entry point for running logistics module for truck demand within Finland
@@ -887,9 +927,18 @@ class FreightPurpose(Purpose):
 
         mapping_name = (self.generation_zone_data.mapping.name if self.is_export 
                         else self.attraction_zone_data.mapping.name)
+        all_zones = self.generation_zone_data.all_zone_numbers
         if mapping_name == "municipality_center":
             df = pandas.DataFrame(demand, trade_mappings["finland_zone_number"])
             demand = df.groupby(self.generation_zone_data.mapping).sum().to_numpy()
+        elif demand.shape[0] != self.orig_zone_numbers.size:
+            idx_names = ["finland_zone_number", "cluster_zone_number"]
+            idx = [None, None]
+            for i, name in enumerate(idx_names):
+                mapping_arr = numpy.array(trade_mappings[name], dtype=all_zones.dtype)
+                mask = numpy.isin(all_zones, mapping_arr)
+                idx[i] = numpy.where(mask)[0].astype(numpy.int32)
+            demand = demand[numpy.ix_(idx[0], idx[1])]
         demand = demand.T if not self.is_export else demand
 
         # Finland border control point key - zone index

--- a/Scripts/tests/unit/test_freight_demand.py
+++ b/Scripts/tests/unit/test_freight_demand.py
@@ -11,7 +11,7 @@ from datahandling.resultdata import ResultsData
 from datahandling.zonedata import FreightZoneData
 from utils.freight_utils import (
     create_purposes, write_leg2_summary, write_purpose_summary, 
-    write_zone_summary, write_vehicle_summary
+    write_zone_summary, write_vehicle_summary, write_domestic_leg_summary
 )
 
 TEST_PATH = Path(__file__).parent.parent / "test_data"
@@ -74,9 +74,9 @@ class FreightModelTest(unittest.TestCase):
 
         total_demand = {mode: numpy.zeros_like(impedance["truck"]["time"])
                         for mode in param.truck_classes}
-
         for purpose in purposes.values():
             demand = purpose.calc_traffic(impedance)
+            demand_trade = purpose.calc_trade_mode_share(demand, trade_demand, fin_borders)
             costs = purpose.get_costs(impedance)
             self._assert_calc_demand_results(demand, costs)
             aux_demand = {
@@ -88,6 +88,7 @@ class FreightModelTest(unittest.TestCase):
                 total_demand[mode] += purpose.calc_vehicles(ton_demand, mode)
             write_purpose_summary(purpose, demand, aux_demand, impedance, resultdata)
             write_zone_summary(purpose.name, zonedata.zone_numbers, demand, resultdata)
+            write_domestic_leg_summary(demand_trade, impedance, resultdata)
         write_vehicle_summary(total_demand, impedance, resultdata)
         resultdata.flush()
 
@@ -125,7 +126,7 @@ class FreightModelTest(unittest.TestCase):
                                fin_border, cluster_border, resultdata)
             trade_demand[purpose.name] = demand
         resultdata.flush()
-        return trade_demand, fin_border
+        return trade_demand, list(fin_border.values())
 
     def _assert_calc_demand_results(self, demand, costs):
         for mode in demand:

--- a/Scripts/tests/unit/test_freight_demand.py
+++ b/Scripts/tests/unit/test_freight_demand.py
@@ -9,7 +9,10 @@ import openmatrix as omx
 import parameters.assignment as param
 from datahandling.resultdata import ResultsData
 from datahandling.zonedata import FreightZoneData
-from utils.freight_utils import create_purposes
+from utils.freight_utils import (
+    create_purposes, write_leg2_summary, write_purpose_summary, 
+    write_zone_summary, write_vehicle_summary
+)
 
 TEST_PATH = Path(__file__).parent.parent / "test_data"
 TEST_DATA_PATH = TEST_PATH / "Scenario_input_data"
@@ -57,6 +60,8 @@ class FreightModelTest(unittest.TestCase):
                 "canal_cost": numpy.zeros([len(ZONE_NUMBERS), len(ZONE_NUMBERS)])
             }
         }
+        impedance["semi_trailer"] = impedance["truck"]
+        impedance["trailer_truck"] = impedance["truck"]
 
         trade_demand, fin_borders = self.run_trade_route_choice(zonedata, resultdata, 
                                                                 costdata, impedance)
@@ -67,17 +72,24 @@ class FreightModelTest(unittest.TestCase):
                                    resultdata, costdata["freight"])
         self.assertEqual(len(purposes), 2)
 
+        total_demand = {mode: numpy.zeros_like(impedance["truck"]["time"])
+                        for mode in param.truck_classes}
+
         for purpose in purposes.values():
             demand = purpose.calc_traffic(impedance)
-            demand_trade = purpose.calc_trade_mode_share(demand, trade_demand, 
-                                                         fin_borders)
             costs = purpose.get_costs(impedance)
-            for mode in demand:
-                self.assertTrue(numpy.isfinite(demand[mode]).all())
-                if mode == param.truck_classes[0]:
-                    self.assertTrue(numpy.isfinite(costs[mode]["cost"]).all())
-                else:
-                    self.assertTrue(numpy.isfinite(costs[mode]["cost"]).any())
+            self._assert_calc_demand_results(demand, costs)
+            aux_demand = {
+                mode: numpy.ones_like(impedance["truck"]["time"])
+                for mode in demand if mode != "truck"
+            }
+            for mode in param.truck_classes:
+                ton_demand = demand["truck"] + sum(aux_demand.values())
+                total_demand[mode] += purpose.calc_vehicles(ton_demand, mode)
+            write_purpose_summary(purpose, demand, aux_demand, impedance, resultdata)
+            write_zone_summary(purpose.name, zonedata.zone_numbers, demand, resultdata)
+        write_vehicle_summary(total_demand, impedance, resultdata)
+        resultdata.flush()
 
 
     def run_trade_route_choice(self, zonedata, resultdata, costdata, impedance):
@@ -107,6 +119,18 @@ class FreightModelTest(unittest.TestCase):
 
         trade_demand = {}
         for purpose in purposes.values():
-            trade_demand[purpose.name] = purpose.run_trade_route_module(
+            demand = purpose.run_trade_route_module(
                 impedance, *marine_attr, trade_demand_path)
+            write_leg2_summary(purpose, demand, marine_modes, 
+                               fin_border, cluster_border, resultdata)
+            trade_demand[purpose.name] = demand
+        resultdata.flush()
         return trade_demand, fin_border
+
+    def _assert_calc_demand_results(self, demand, costs):
+        for mode in demand:
+            self.assertTrue(numpy.isfinite(demand[mode]).all())
+            if mode == param.truck_classes[0]:
+                self.assertTrue(numpy.isfinite(costs[mode]["cost"]).all())
+            else:
+                self.assertTrue(numpy.isfinite(costs[mode]["cost"]).any())

--- a/Scripts/tests/unit/test_freight_demand.py
+++ b/Scripts/tests/unit/test_freight_demand.py
@@ -24,16 +24,13 @@ ZONE_NUMBERS = [202, 1344, 1755, 2037, 2129, 2224, 2333, 2413, 2519, 2621,
 
 class FreightModelTest(unittest.TestCase):
 
-    def test_freight_model(self):      
+    def test_freight_model(self):
         zonedata = FreightZoneData(
             TEST_DATA_PATH / "freight_zonedata.gpkg", numpy.array(ZONE_NUMBERS),
             "koko_suomi")
         resultdata = ResultsData(RESULT_PATH)
         with open(TEST_DATA_PATH / "costdata.json") as file:
             costdata = json.load(file)
-        purposes = create_purposes(PARAMETERS_PATH / "domestic", zonedata, 
-                                   resultdata, costdata["freight"])
-        self.assertGreaterEqual(len(purposes), 1)
         
         time_impedance = omx.open_file(TEST_MATRICES / "freight_time.omx", "r")
         dist_impedance = omx.open_file(TEST_MATRICES / "freight_dist.omx", "r")
@@ -60,12 +57,20 @@ class FreightModelTest(unittest.TestCase):
                 "canal_cost": numpy.zeros([len(ZONE_NUMBERS), len(ZONE_NUMBERS)])
             }
         }
+
+        trade_demand, fin_borders = self.run_trade_route_choice(zonedata, resultdata, 
+                                                                costdata, impedance)
         for mtx_type in impedance.keys():
             for ass_class, mtx in impedance[mtx_type].items():
                 impedance[mtx_type][ass_class] = mtx[:zonedata.nr_zones, :zonedata.nr_zones]
-        
+        purposes = create_purposes(PARAMETERS_PATH / "domestic", zonedata, 
+                                   resultdata, costdata["freight"])
+        self.assertEqual(len(purposes), 2)
+
         for purpose in purposes.values():
             demand = purpose.calc_traffic(impedance)
+            demand_trade = purpose.calc_trade_mode_share(demand, trade_demand, 
+                                                         fin_borders)
             costs = purpose.get_costs(impedance)
             for mode in demand:
                 self.assertTrue(numpy.isfinite(demand[mode]).all())
@@ -73,3 +78,35 @@ class FreightModelTest(unittest.TestCase):
                     self.assertTrue(numpy.isfinite(costs[mode]["cost"]).all())
                 else:
                     self.assertTrue(numpy.isfinite(costs[mode]["cost"]).any())
+
+
+    def run_trade_route_choice(self, zonedata, resultdata, costdata, impedance):
+        marine_modes = ("container_ship", "roro_vessel")
+        fin_border = {"FIHKO": 4102, "FIHMN": 19401}
+        cluster_border = {"EETLL": 50107, "SESTO": 50127}
+        trade_demand_path = Path(TEST_MATRICES / "trade_demand.omx")
+
+        purposes = create_purposes(PARAMETERS_PATH / "foreign", zonedata, 
+                                   resultdata, costdata["freight"])
+        del purposes["kummuo_export"]
+        del purposes["kummuo_import"]
+        self.assertEqual(len(purposes), 2)
+
+        ship_imps = {
+            mode: {
+                imp: numpy.full((len(fin_border), len(fin_border)), 
+                                numpy.inf, dtype="float32")
+                for imp in ("dist", "frequency")}
+            for mode in marine_modes
+        }
+        ship_imps["container_ship"]["dist"][1][1] = 532
+        ship_imps["container_ship"]["frequency"][1][1] = 38
+        ship_imps["roro_vessel"]["dist"][0][0] = 126
+        ship_imps["roro_vessel"]["frequency"][0][0] = 162
+        marine_attr = (ship_imps, fin_border, cluster_border)
+
+        trade_demand = {}
+        for purpose in purposes.values():
+            trade_demand[purpose.name] = purpose.run_trade_route_module(
+                impedance, *marine_attr, trade_demand_path)
+        return trade_demand, fin_border

--- a/Scripts/utils/freight_utils.py
+++ b/Scripts/utils/freight_utils.py
@@ -63,10 +63,10 @@ def write_domestic_leg_summary(demand_trade: dict, impedance: dict,
     for purpose in demand_trade:
         trade_type = "export" if purpose.is_export else "import"
         modes = list(demand_trade[purpose])
-        mode_tons = [numpy.sum(demand_trade[purpose][mode], dtype=int)
+        mode_tons = [numpy.sum(demand_trade[purpose][mode], dtype=numpy.int32)
                      for mode in modes]
         mode_ton_dist = [numpy.sum(demand_trade[purpose][mode]
-                                   * impedance[mode]["dist"], dtype=int)
+                                   * impedance[mode]["dist"], dtype=numpy.int64)
                         for mode in modes]
         df_data.append(DataFrame(data={
             "Commodity": [purpose.name] * len(modes),

--- a/Scripts/utils/freight_utils.py
+++ b/Scripts/utils/freight_utils.py
@@ -91,7 +91,7 @@ def write_domestic_leg_summary(demand_trade: dict, impedance: dict,
     for purpose in demand_trade:
         trade_type = "export" if purpose.is_export else "import"
         modes = list(demand_trade[purpose])
-        mode_tons = [numpy.sum(demand_trade[purpose][mode], dtype=numpy.int32)
+        mode_tons = [numpy.sum(demand_trade[purpose][mode], dtype=numpy.float32)
                      for mode in modes]
         mode_ton_dist = [numpy.sum(demand_trade[purpose][mode]
                                    * impedance[mode]["dist"], dtype=numpy.int64)

--- a/Scripts/utils/freight_utils.py
+++ b/Scripts/utils/freight_utils.py
@@ -86,26 +86,22 @@ def write_domestic_leg_summary(demand_trade: dict, impedance: dict,
                                resultdata: ResultsData):
     """Write summary for trade demand's domestic leg including transported
     commodity, trade type (export/import), mode, tons and ton mileage.
-    '"""
-    df_data = []
-    for purpose in demand_trade:
-        trade_type = "export" if purpose.is_export else "import"
-        modes = list(demand_trade[purpose])
-        mode_tons = [numpy.sum(demand_trade[purpose][mode], dtype=numpy.float32)
-                     for mode in modes]
-        mode_ton_dist = [numpy.sum(demand_trade[purpose][mode]
-                                   * impedance[mode]["dist"], dtype=numpy.int64)
-                        for mode in modes]
-        df_data.append(DataFrame(data={
-            "Commodity": [purpose.name] * len(modes),
-            "Type": [trade_type] * len(modes),
-            "Mode": modes,
-            "Tons (t/annual)": mode_tons,
-            "Ton mileage (tkm/annual)": mode_ton_dist
-            })
-        )
+    """
+    rows = [
+        {
+            "Commodity": name,
+            "Type": trade_type,
+            "Mode": mode,
+            "Tons (t/annual)": numpy.sum(demand_trade[purpose][mode], dtype=numpy.float32),
+            "Ton mileage (tkm/annual)": numpy.sum(
+                demand_trade[purpose][mode] * impedance[mode]["dist"], dtype=numpy.int64),
+        }
+        for purpose in demand_trade
+        for name, trade_type in [purpose.split("_")]
+        for mode in demand_trade[purpose]
+    ]
     filename = "freight_domestic_leg_summary.txt"
-    resultdata.print_concat(concat(df_data, ignore_index=True), filename)
+    resultdata.print_concat(DataFrame(rows), filename)
 
 def write_purpose_summary(purpose: FreightPurpose, demand: dict, aux_demand: dict, 
                           impedance: dict, resultdata: ResultsData):

--- a/Scripts/utils/freight_utils.py
+++ b/Scripts/utils/freight_utils.py
@@ -2,6 +2,7 @@ import json
 import numpy
 from pathlib import Path
 from typing import Dict
+from pandas import DataFrame, concat
 
 import utils.log as log
 from datatypes.purpose import FreightPurpose
@@ -52,6 +53,31 @@ def create_purposes(parameters_path: Path, zonedata: FreightZoneData,
                                                             zone_data, resultdata,
                                                             purpose_cost)
     return purposes
+
+def write_domestic_leg_summary(demand_trade: dict, impedance: dict,
+                               resultdata: ResultsData):
+    """Write summary for trade demand's domestic leg including transported
+    commodity, trade type (export/import), mode, tons and ton mileage.
+    '"""
+    df_data = []
+    for purpose in demand_trade:
+        trade_type = "export" if purpose.is_export else "import"
+        modes = list(demand_trade[purpose])
+        mode_tons = [numpy.sum(demand_trade[purpose][mode], dtype=int)
+                     for mode in modes]
+        mode_ton_dist = [numpy.sum(demand_trade[purpose][mode]
+                                   * impedance[mode]["dist"], dtype=int)
+                        for mode in modes]
+        df_data.append(DataFrame(data={
+            "Commodity": [purpose.name] * len(modes),
+            "Type": [trade_type] * len(modes),
+            "Mode": modes,
+            "Tons (t/annual)": mode_tons,
+            "Ton mileage (tkm/annual)": mode_ton_dist
+            })
+        )
+    filename = "freight_domestic_leg_summary.txt"
+    resultdata.print_concat(concat(df_data, ignore_index=True), filename)
 
 class StoreDemand():
     """Handles demand dimension compatibility when storing demand matrices 

--- a/Scripts/valma_freight.py
+++ b/Scripts/valma_freight.py
@@ -68,7 +68,7 @@ def main(args):
         write_leg2_summary(purpose, demand, *marine_data, resultdata)
         trade_demand[purpose.name] = demand
     resultdata.flush()
-    fin_borders = marine_export[1]
+    fin_border_ids = list(marine_export[1].values())
     marine_export, marine_import = None, None
 
     # prepare domestic model by splicing impedances and initializing final demand matrix 
@@ -84,7 +84,7 @@ def main(args):
     for purpose in purposes.values():
         log.info(f"Calculating demand for purpose: {purpose.name}")
         demand = purpose.calc_traffic(impedance)
-        demand_trade = purpose.calc_trade_mode_share(demand, trade_demand, fin_borders)
+        demand_trade = purpose.calc_trade_mode_share(demand, trade_demand, fin_border_ids)
         if purpose.route_params and args.logistics_iterations > 0:
             demand["truck"], _ = purpose.run_logistics_module(demand["truck"], impedance, 
                                                               ass_model.mapping, 

--- a/Scripts/valma_freight.py
+++ b/Scripts/valma_freight.py
@@ -83,8 +83,7 @@ def main(args):
     for purpose in purposes.values():
         log.info(f"Calculating demand for purpose: {purpose.name}")
         demand = purpose.calc_traffic(impedance)
-        trade_truck_demand = purpose.calc_trade_mode_share(demand, trade_demand, 
-                                                           fin_borders)
+        demand_trade = purpose.calc_trade_mode_share(demand, trade_demand, fin_borders)
         if purpose.route_params and args.logistics_iterations > 0:
             demand["truck"], _ = purpose.run_logistics_module(demand["truck"], impedance, 
                                                               ass_model.mapping, 

--- a/Scripts/valma_freight.py
+++ b/Scripts/valma_freight.py
@@ -66,7 +66,7 @@ def main(args):
         demand = purpose.run_trade_route_module(impedance, *marine_data,
                                                 trade_demand_file)
         write_leg2_summary(purpose, demand, *marine_data, resultdata)
-        trade_demand[purpose] = demand
+        trade_demand[purpose.name] = demand
     resultdata.flush()
     fin_borders = marine_export[1]
     marine_export, marine_import = None, None

--- a/Scripts/valma_freight.py
+++ b/Scripts/valma_freight.py
@@ -15,7 +15,7 @@ from assignment.emme_bindings.emme_project import EmmeProject
 from datahandling.matrixdata import MatrixData
 from datatypes.purpose import FreightPurpose
 
-from utils.freight_utils import create_purposes, StoreDemand
+from utils.freight_utils import create_purposes, StoreDemand, write_domestic_leg_summary
 from datahandling.traversaldata import transform_traversal_data
 from parameters.commodity import commodity_conversion
 
@@ -66,7 +66,7 @@ def main(args):
         else:
             demand = purpose.run_trade_route_module(impedance, *marine_import,
                                                     trade_demand_file)
-        trade_demand[purpose.name] = demand
+        trade_demand[purpose] = demand
     fin_borders = marine_export[1]
     marine_export, marine_import = None, None
 
@@ -101,6 +101,7 @@ def main(args):
             total_demand[mode] += purpose.calc_vehicles(ton_demand, mode)
         write_purpose_summary(purpose, demand, aux_demand, impedance, resultdata)
         write_zone_summary(purpose.name, zonedata.zone_numbers, demand, resultdata)
+        write_domestic_leg_summary(demand_trade, impedance, resultdata)
     write_vehicle_summary(total_demand, impedance, resultdata)
     resultdata.flush()
     

--- a/Scripts/valma_freight.py
+++ b/Scripts/valma_freight.py
@@ -67,6 +67,7 @@ def main(args):
             demand = purpose.run_trade_route_module(impedance, *marine_import,
                                                     trade_demand_file)
         trade_demand[purpose.name] = demand
+    fin_borders = marine_export[1]
     marine_export, marine_import = None, None
 
     # prepare domestic model by splicing impedances and initializing final demand matrix 
@@ -82,6 +83,8 @@ def main(args):
     for purpose in purposes.values():
         log.info(f"Calculating demand for purpose: {purpose.name}")
         demand = purpose.calc_traffic(impedance)
+        trade_truck_demand = purpose.calc_trade_mode_share(demand, trade_demand, 
+                                                           fin_borders)
         if purpose.route_params and args.logistics_iterations > 0:
             demand["truck"], _ = purpose.run_logistics_module(demand["truck"], impedance, 
                                                               ass_model.mapping, 


### PR DESCRIPTION
In our current design structure, the domestic leg for each of our traded commodities has just one estimated mode that is truck. This is because of lack in freight train related estimation data. However we would also like to understand what is the potential that could be transported with freight train between zones and border control points. Therefore we can use modelled results of our domestic purposes to gain some understanding of distribution between truck and freight train.

Note that all of our domestic models do not have freight train as a mode alternative meaning that freight train will not become a land mode alternative for that purpose's foreign models.