### PR TITLE
Refactor handling of matrices and dimensions in `ZoneData`

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -206,9 +206,6 @@ class ZoneData:
         return {key: val for key, val in self._values.items()
             if isinstance(val, pandas.Series)}
 
-    def __getitem__(self, key):
-        return self._values[key]
-
     def __setitem__(self, key: str, data: pandas.Series):
         try:
             if not numpy.isfinite(data).all():
@@ -255,26 +252,15 @@ class ZoneData:
         """
         return self.zones[zone_number].index
 
-    def get_data(self, key: str) -> Union[pandas.Series, numpy.ndarray]:
-        """Get data of correct shape for zones included in purpose.
-        
-        Parameters
-        ----------
-        key : str
-            Key describing the data (e.g., "population")
-
-        Returns
-        -------
-        pandas Series or numpy 2-d matrix
-        """
+    def __getitem__(self, key: str) -> Union[pandas.Series, numpy.ndarray]:
         try:
-            return self._values[key].values
+            return self._values[key]
         except KeyError as err:
             keyl: List[str] = key.split('*')
             mun_idx = self.demand_aggs.mappings["municipality"].to_numpy()
             if (len(keyl) == 2):
                 # If parameter is two-fold, they will be multiplied
-                return self.get_data(keyl[0]) * self.get_data(keyl[1])
+                return numpy.asarray(self[keyl[0]]) * numpy.asarray(self[keyl[1]])
             elif "within_zone" in key:
                 mtx = numpy.zeros(
                     (self.nr_zones, self.nr_zones), dtype=numpy.float32)

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -39,7 +39,7 @@ class ZoneData:
     car_dist_cost : float
         Car cost (eur) per km
     """
-    distance: numpy.ndarray
+    beeline_dist: numpy.ndarray
 
     def __init__(self, *args, **kwargs):
         self._init_data(*args, **kwargs)
@@ -55,9 +55,9 @@ class ZoneData:
         all_zone_numbers = numpy.array(zone_numbers)
         self.all_zone_numbers = all_zone_numbers
         area = param.purpose_areas[model_area]
+        self.zone_slice = slice(*all_zone_numbers.searchsorted(area))
         self.zone_numbers = pandas.Index(
-            all_zone_numbers[slice(*all_zone_numbers.searchsorted(area))],
-            name="analysis_zone_id")
+            all_zone_numbers[self.zone_slice], name="analysis_zone_id")
         Zone.counter = 0
         data, mapping = read_zonedata(
             data_path, self.zone_numbers, zone_mapping, data_type)
@@ -273,8 +273,7 @@ class ZoneData:
             elif key == "outside_municipality":
                 return mun_idx[:, numpy.newaxis] != mun_idx
             elif "beeline" in key:
-                idx = numpy.isin(self.zone_numbers, self.all_zone_numbers)
-                mtx = self.distance[numpy.ix_(idx, idx)]
+                mtx = self.beeline_dist[self.zone_slice, self.zone_slice]
                 try:  # If key contains km interval (e.g., "beeline_10_100_km")
                     _, lower, upper, _ = key.split('_')
                 except ValueError:

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -39,6 +39,8 @@ class ZoneData:
     car_dist_cost : float
         Car cost (eur) per km
     """
+    distance: numpy.ndarray
+
     def __init__(self, *args, **kwargs):
         self._init_data(*args, **kwargs)
 
@@ -123,22 +125,11 @@ class ZoneData:
         self["pop_density"] = divide(data["population"], data["land_area"])
         self["log_pop_density"] = numpy.log(self["pop_density"]+1)
 
-        # Create diagonal matrix
-        self["within_zone"] = numpy.full((self.nr_zones, self.nr_zones), 0.0)
-        self["within_zone"][numpy.diag_indices(self.nr_zones)] = 1.0
         # Two-way intrazonal distances from building distances
         self["dist"] = data["avg_building_distance"] * 2
         self["time"] = self["dist"] / (20/60) # 20 km/h
         self["cost"] = car_dist_cost * self["dist"]
-        # Unavailability of intrazonal tours
-        self["within_zone_inf"] = numpy.full((self.nr_zones, self.nr_zones), 0.0)
-        self["within_zone_inf"][numpy.diag_indices(self.nr_zones)] = numpy.inf
-        # Create matrix where value is True if origin and destination is in
-        # same municipality
-        municipalities = self.demand_aggs.mappings["municipality"].values
-        within_municipality = municipalities[:, numpy.newaxis] == municipalities
-        self["within_municipality"] = within_municipality
-        self["outside_municipality"] = ~within_municipality
+
         dummies = {
             "zone": {},
             "municipality": {},
@@ -264,35 +255,46 @@ class ZoneData:
         """
         return self.zones[zone_number].index
 
-    def get_data(self, key: str, bounds: slice, generation: bool=False) -> Union[pandas.Series, numpy.ndarray]:
+    def get_data(self, key: str) -> Union[pandas.Series, numpy.ndarray]:
         """Get data of correct shape for zones included in purpose.
         
         Parameters
         ----------
         key : str
             Key describing the data (e.g., "population")
-        bounds : slice
-            Slice that describes the lower and upper bounds of purpose
-        generation : bool, optional
-            If set to True, returns data only for zones in purpose,
-            otherwise returns data for all zones
-        
+
         Returns
         -------
         pandas Series or numpy 2-d matrix
         """
         try:
-            val = self._values[key]
+            return self._values[key].values
         except KeyError as err:
             keyl: List[str] = key.split('*')
+            mun_idx = self.demand_aggs.mappings["municipality"].values
             if (len(keyl) == 2):
                 # If parameter is two-fold, they will be multiplied
-                return (self.get_data(keyl[0], bounds, generation)
-                        * self.get_data(keyl[1], bounds, generation))
+                return self.get_data(keyl[0]) * self.get_data(keyl[1])
+            elif "within_zone" in key:
+                mtx = numpy.zeros(
+                    (self.nr_zones, self.nr_zones), dtype=numpy.float32)
+                numpy.fill_diagonal(mtx, numpy.inf if "inf" in key else 1.0)
+                return mtx
+            elif key == "within_municipality":
+                # Create matrix with True if origin and destination
+                # is in same municipality
+                return mun_idx[:, numpy.newaxis] == mun_idx
+            elif key == "outside_municipality":
+                return mun_idx[:, numpy.newaxis] != mun_idx
             elif "beeline" in key:
-                beeline, lower, upper, _ = key.split('_')
-                mtx = self[beeline]
-                return (mtx > int(lower)) & (mtx <= int(upper))[bounds, :]
+                idx = numpy.isin(self.zone_numbers, self.all_zone_numbers)
+                mtx = self.distance[numpy.ix_(idx, idx)]
+                try:  # If key contains km interval (e.g., "beeline_10_100_km")
+                    _, lower, upper, _ = key.split('_')
+                except ValueError:
+                    return mtx
+                else:
+                    return (mtx > int(lower)) & (mtx <= int(upper))
             elif "municipality_calibration" in key:
                 try:
                     # Try to find mode-specific calibration matrix
@@ -300,18 +302,10 @@ class ZoneData:
                 except KeyError:
                     return 0
                 else:
-                    idx = self.demand_aggs.mappings["municipality"].values
                     return calib.unstack("attraction").reindex(
-                        index=idx, columns=idx, fill_value=0.0).values[bounds, :]
+                        index=mun_idx, columns=mun_idx, fill_value=0.0).values
             else:
                 raise KeyError(err)
-        if val.ndim == 1: # If not a compound (i.e., matrix)
-            if generation:  # Return values for purpose zones
-                return val[bounds].values
-            else:  # Return values for all zones
-                return val.values
-        else:  # Return matrix (purpose zones -> all zones)
-            return val[bounds, :]
 
     @property
     def is_in_submodel(self) -> pandas.Series:

--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -271,7 +271,7 @@ class ZoneData:
             return self._values[key].values
         except KeyError as err:
             keyl: List[str] = key.split('*')
-            mun_idx = self.demand_aggs.mappings["municipality"].values
+            mun_idx = self.demand_aggs.mappings["municipality"].to_numpy()
             if (len(keyl) == 2):
                 # If parameter is two-fold, they will be multiplied
                 return self.get_data(keyl[0]) * self.get_data(keyl[1])
@@ -303,7 +303,8 @@ class ZoneData:
                     return 0
                 else:
                     return calib.unstack("attraction").reindex(
-                        index=mun_idx, columns=mun_idx, fill_value=0.0).values
+                        index=mun_idx, columns=mun_idx, fill_value=0.0
+                    ).to_numpy(numpy.float32)
             else:
                 raise KeyError(err)
 

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -55,7 +55,6 @@ class Purpose:
     mtx_adjustment : dict (optional)
         Dict of matrix adjustments for testing elasticities
     """
-    distance: numpy.ndarray
 
     def __init__(self, 
                  specification: Dict[str,Optional[str]],
@@ -287,7 +286,8 @@ class TourPurpose(Purpose):
                 self.bounds, resultdata)
         else:
             log.error(f"Tour generation model not defined for {self.name}")
-        args = (self, specification, self.attraction_zone_data, resultdata)
+        args = (self, specification, self.generation_zone_data,
+                self.attraction_zone_data, resultdata)
         if specification["struct"] == "mode>dest":
             self.model = logit.ModeDestModel(*args)
         elif specification["struct"] == "dest>mode":
@@ -306,7 +306,8 @@ class TourPurpose(Purpose):
                 new_spec = copy(specification)
                 new_spec["mode_choice"] = new_spec["access_mode_choice"][mode]
                 self.connection_models[mode] = logit.LogitModel(
-                    self, new_spec, self.generation_zone_data, resultdata)
+                    self, new_spec, self.generation_zone_data,
+                    self.attraction_zone_data, resultdata)
         self.histograms = {mode: TourLengthHistogram(self.name)
             for mode in self.modes}
         self.orig_mappings = self.generation_zone_data.result_aggs.mappings
@@ -317,7 +318,7 @@ class TourPurpose(Purpose):
 
     @property
     def dist(self):
-        return self.distance[self.bounds, self.dest_interval]
+        return ZoneData.distance[self.bounds, self.dest_interval]
     
     @property
     def generated_tours_all(self):
@@ -675,13 +676,12 @@ class FreightPurpose(Purpose):
         self.costdata = costdata
         self.model_category = list(zone_data)[0]
         self.modes: List[str] = list(specification["mode_choice"])
-
+        args = (self, specification, self.generation_zone_data,
+                self.attraction_zone_data, resultdata)
         if specification["struct"] == "dest>mode":
-            self.model = logit.DestModeModel(self, specification, zone_data[self.model_category], 
-                                             resultdata)
+            self.model = logit.DestModeModel(*args)
         elif specification["struct"] == "mode>dest":
-            self.model = logit.ModeDestModel(self, specification, zone_data[self.model_category], 
-                                             resultdata)
+            self.model = logit.ModeDestModel(*args)
         else:
             self.model = None
         self.route_params = specification.get("route_choice", None)

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -318,7 +318,7 @@ class TourPurpose(Purpose):
 
     @property
     def dist(self):
-        return ZoneData.distance[self.bounds, self.dest_interval]
+        return ZoneData.beeline_dist[self.bounds, self.dest_interval]
     
     @property
     def generated_tours_all(self):

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -30,8 +30,10 @@ class LogitModel:
         Tour purpose (type of tour)
     parameters : dict
         See `datatypes.purpose.new_tour_purpose()`
-    zone_data : ZoneData
-        Data used for all demand calculations
+    generation_zone_data : ZoneData
+        Data used for generation calculations
+    attraction_zone_data : ZoneData
+        Data used for attraction calculations
     resultdata : ResultData
         Writer object to result directory
     """
@@ -39,12 +41,13 @@ class LogitModel:
     def __init__(self, 
                  purpose: TourPurpose,
                  parameters: dict,
-                 zone_data: ZoneData,
+                 generation_zone_data: ZoneData,
+                 attraction_zone_data: ZoneData,
                  resultdata: ResultsData):
         self.resultdata = resultdata
         self.purpose = purpose
-        self.bounds = purpose.bounds
-        self.zone_data = zone_data
+        self.generation_zone_data = generation_zone_data
+        self.attraction_zone_data = attraction_zone_data
         self.mode_utils: Dict[str, numpy.ndarray] = {}
         self.dest_choice_param: Dict[str, Dict[str, Any]] = parameters["destination_choice"]
         self.mode_choice_param: Optional[Dict[str, Dict[str, Any]]] = parameters["mode_choice"]
@@ -172,14 +175,15 @@ class LogitModel:
             geographical area in which this model is used based on the
             `self.bounds` attribute of this class.
         """
-        zdata = self.zone_data
+        zdata = (self.generation_zone_data if generation
+                 else self.attraction_zone_data)
         for i in b:
-            utility += b[i] * zdata.get_data(i, self.bounds, generation)
+            utility += b[i] * zdata.get_data(i)
         return utility
     
     def _add_sec_zone_util(self, utility, b):
         for i in b:
-            data = self.zone_data.get_data(i, self.bounds, generation=True)
+            data = self.generation_zone_data.get_data(i)
             utility += b[i] * data
         return utility
 
@@ -202,10 +206,11 @@ class LogitModel:
             geographical area in which this model is used based on the
             `self.bounds` attribute of this class.
         """
-        zdata = self.zone_data
+        zdata = (self.generation_zone_data if generation
+                 else self.attraction_zone_data)
         for i in b:
             exps *= numpy.power(
-                zdata.get_data(i, self.bounds, generation) + 1, b[i])
+                zdata.get_data(i) + 1, b[i])
         return exps
 
 
@@ -395,7 +400,7 @@ class ModeDestModel(LogitModel):
         logsum = pandas.Series(
             log(mode_expsum), self.purpose.orig_zone_numbers,
             name=self.purpose.name)
-        self.zone_data._values[self.purpose.name] = logsum
+        self.generation_zone_data._values[self.purpose.name] = logsum
         return mode_exps, mode_expsum, dest_exps, dest_expsums
 
     def _calc_exps(self,
@@ -413,7 +418,7 @@ class ModeDestModel(LogitModel):
             label = self.purpose.name + "_" + mode
             logsum = pandas.Series(
                 log(expsum), self.purpose.orig_zone_numbers, name=label)
-            self.zone_data._values[label] = logsum
+            self.generation_zone_data._values[label] = logsum
             mode_exps[mode] = self._calc_mode_util(mode, dest_expsums[mode])
         return mode_exps, dest_exps, dest_expsums
 
@@ -431,8 +436,7 @@ class ModeDestModel(LogitModel):
         no_dummy_share = 1.0
         for dummy, modes in dummies.items():
             try:
-                dummy_share = self.zone_data.get_data(
-                    dummy, self.bounds, generation=True)
+                dummy_share = self.generation_zone_data.get_data(dummy)
             except KeyError:
                 self._stashed_exps = [mode_exps, mode_expsum]
                 return None
@@ -466,11 +470,11 @@ class ModeDestModel(LogitModel):
         Individual dummy variables are not included.
         """
         self.accessibility: Dict[str, pandas.Series] = {}
-        self.accessibility["all"] = self.zone_data[self.purpose.name]
+        self.accessibility["all"] = self.generation_zone_data[self.purpose.name]
         sustainable_expsum = numpy.zeros_like(mode_expsum)
         car_expsum = numpy.zeros_like(mode_expsum)
         for mode in self.mode_choice_param:
-            logsum = self.zone_data[f"{self.purpose.name}_{mode}"]
+            logsum = self.generation_zone_data[f"{self.purpose.name}_{mode}"]
             self.accessibility[mode] = logsum
             if "car" in mode:
                 car_expsum += mode_exps[mode]
@@ -479,7 +483,7 @@ class ModeDestModel(LogitModel):
         label = f"{self.purpose.name}_sustainable"
         logsum_sustainable = pandas.Series(
             log(sustainable_expsum), self.purpose.orig_zone_numbers, name=label)
-        self.zone_data._values[label] = logsum_sustainable
+        self.generation_zone_data._values[label] = logsum_sustainable
         self.accessibility["sustainable"] = logsum_sustainable
         self.accessibility["car"] = pandas.Series(
             log(car_expsum), self.purpose.orig_zone_numbers,
@@ -544,8 +548,7 @@ class DestModeModel(LogitModel):
         no_dummy_share = 1.0
         prob = defaultdict(float)
         for dummy in dummies:
-            dummy_share = self.zone_data.get_data(
-                dummy, self.bounds, generation=True)
+            dummy_share = self.generation_zone_data.get_data(dummy)
             no_dummy_share -= dummy_share
             tmp_prob = self._calc_prob(impedance, dummy)
             for mode in self.mode_choice_param:
@@ -569,7 +572,7 @@ class DestModeModel(LogitModel):
                 log(dest_expsum), self.purpose.orig_zone_numbers,
                 name=self.purpose.name)
             self.accessibility = {"all": logsum}
-            self.zone_data._values[self.purpose.name] = logsum
+            self.generation_zone_data._values[self.purpose.name] = logsum
         prob: Dict[str, numpy.ndarray] = {}
         dest_prob = divide(dest_exps.T, dest_expsum)
         for mode in self.mode_choice_param:
@@ -648,7 +651,7 @@ class GenerationLogit(LogitModel):
                  bounds: slice, 
                  resultdata: ResultsData):
         self.resultdata = resultdata
-        self.zone_data = zone_data
+        self.generation_zone_data = zone_data
         self.bounds = bounds
         attempt_calibration(parameters)
         self.param = parameters
@@ -695,8 +698,7 @@ class GenerationLogit(LogitModel):
                 nr_expsum += nr_exp[nr]
             for nr in self.param:
                 ind_prob = nr_exp[nr] / nr_expsum
-                dummy_share = self.zone_data.get_data(
-                    dummy, self.bounds, generation=True)
+                dummy_share = self.generation_zone_data.get_data(dummy)
                 with_dummy = dummy_share * ind_prob
                 prob[nr] += with_dummy
         return prob

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -178,12 +178,12 @@ class LogitModel:
         zdata = (self.generation_zone_data if generation
                  else self.attraction_zone_data)
         for i in b:
-            utility += b[i] * zdata.get_data(i)
+            utility += b[i] * numpy.asarray(zdata[i])
         return utility
     
     def _add_sec_zone_util(self, utility, b):
         for i in b:
-            data = self.generation_zone_data.get_data(i)
+            data = self.generation_zone_data[i].to_numpy()
             utility += b[i] * data
         return utility
 
@@ -210,7 +210,7 @@ class LogitModel:
                  else self.attraction_zone_data)
         for i in b:
             exps *= numpy.power(
-                zdata.get_data(i) + 1, b[i])
+                numpy.asarray(zdata[i]) + 1, b[i])
         return exps
 
 
@@ -436,7 +436,7 @@ class ModeDestModel(LogitModel):
         no_dummy_share = 1.0
         for dummy, modes in dummies.items():
             try:
-                dummy_share = self.generation_zone_data.get_data(dummy)
+                dummy_share = numpy.asarray(self.generation_zone_data[dummy])
             except KeyError:
                 self._stashed_exps = [mode_exps, mode_expsum]
                 return None
@@ -548,7 +548,7 @@ class DestModeModel(LogitModel):
         no_dummy_share = 1.0
         prob = defaultdict(float)
         for dummy in dummies:
-            dummy_share = self.generation_zone_data.get_data(dummy)
+            dummy_share = numpy.asarray(self.generation_zone_data[dummy])
             no_dummy_share -= dummy_share
             tmp_prob = self._calc_prob(impedance, dummy)
             for mode in self.mode_choice_param:
@@ -698,7 +698,7 @@ class GenerationLogit(LogitModel):
                 nr_expsum += nr_exp[nr]
             for nr in self.param:
                 ind_prob = nr_exp[nr] / nr_expsum
-                dummy_share = self.generation_zone_data.get_data(dummy)
+                dummy_share = numpy.asarray(self.generation_zone_data[dummy])
                 with_dummy = dummy_share * ind_prob
                 prob[nr] += with_dummy
         return prob

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -183,8 +183,7 @@ class LogitModel:
     
     def _add_sec_zone_util(self, utility, b):
         for i in b:
-            data = self.generation_zone_data[i].to_numpy()
-            utility += b[i] * data
+            utility += b[i] * numpy.asarray(self.generation_zone_data[i])
         return utility
 
     def _add_log_zone_util(self, exps, b, generation=False):

--- a/Scripts/tests/unit/test_logit.py
+++ b/Scripts/tests/unit/test_logit.py
@@ -26,10 +26,10 @@ class LogitModelTest(unittest.TestCase):
         class Purpose:
             pass
         pur = Purpose()
-        zi = numpy.array(INTERNAL_ZONES + EXTERNAL_ZONES)
+        zi = numpy.array(INTERNAL_ZONES)
         zd = ZoneData(ZONEDATA_PATH, zi, "uusimaa", car_dist_cost=0.12)
-        mtx = numpy.arange(720, dtype=numpy.float32)
-        mtx.shape = (24, 30)
+        mtx = numpy.arange(24*24, dtype=numpy.float32)
+        mtx.shape = (24, 24)
         mtx[numpy.diag_indices(24)] = 0
         impedance = {
             "car_drv": {
@@ -63,7 +63,7 @@ class LogitModelTest(unittest.TestCase):
             attempt_calibration(parameters)
             pur.name = parameters["name"]
             if parameters["name"] == "hb_work":
-                args = (pur, parameters, zd, resultdata)
+                args = (pur, parameters, zd, zd, resultdata)
                 model = (DestModeModel(*args)
                     if parameters["struct"] == "dest>mode"
                     else ModeDestModel(*args))

--- a/Scripts/travel_iteration.py
+++ b/Scripts/travel_iteration.py
@@ -271,7 +271,7 @@ class ModelSystem:
         self.dtm = dt.DirectDepartureTimeModel(self.ass_model)
 
         self.ass_model.calc_transit_cost(self.transit_cost)
-        Purpose.distance = self.ass_model.beeline_dist
+        ZoneData.distance = self.ass_model.beeline_dist
         if not isinstance(self.ass_model, MockAssignmentModel):
             with self.resultmatrices.open(
                     "beeline", "", self.ass_model.zone_numbers, m="w") as mtx:
@@ -298,11 +298,6 @@ class ModelSystem:
             self.dtm.init_demand(param.truck_classes)
             self._add_external_demand(
                 self.freight_matrices, param.truck_classes)
-
-        # Add beeline distance dummy
-        zd = self._zone_datas["domestic"]
-        idx = numpy.isin(self.zone_numbers, zd.zone_numbers)
-        zd["beeline"] = Purpose.distance[numpy.ix_(idx, idx)]
 
         # Perform traffic assignment and get result impedance,
         # for each time period

--- a/Scripts/travel_iteration.py
+++ b/Scripts/travel_iteration.py
@@ -271,7 +271,7 @@ class ModelSystem:
         self.dtm = dt.DirectDepartureTimeModel(self.ass_model)
 
         self.ass_model.calc_transit_cost(self.transit_cost)
-        ZoneData.distance = self.ass_model.beeline_dist
+        ZoneData.beeline_dist = self.ass_model.beeline_dist
         if not isinstance(self.ass_model, MockAssignmentModel):
             with self.resultmatrices.open(
                     "beeline", "", self.ass_model.zone_numbers, m="w") as mtx:


### PR DESCRIPTION
- @jalovaj2 discovered that generation and attraction zone data were not handled properly in logit models. This PR fixes that. At the same time, the `bounds` and `generation` arguments in `ZoneData.get_data()` have become obsolete, as we now handle that with the separate generation and attraction `ZoneData` instances. So I removed `ZoneData.get_data()` altogether and replaced it with `ZoneData.__get_item__()`
- Make 2-d matrix handling in `ZoneData` more memory efficient and straightforward.