### PR TITLE
Streamline tour generation, especially non-home

### DIFF
--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -478,9 +478,8 @@ class TourPurpose(Purpose):
         Demand
                 Mode-specific demand matrix for whole day
         """
-        prob = self.calc_prob(impedance, is_last_iteration)
-        self.gen_model.init_tours()
         self.gen_model.add_tours()
+        prob = self.calc_prob(impedance, is_last_iteration)
         tours = self.gen_model.get_tours()
         if prob is None:
             prob = self.model.calc_prob_again()

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -481,8 +481,6 @@ class TourPurpose(Purpose):
         self.gen_model.add_tours()
         prob = self.calc_prob(impedance, is_last_iteration)
         tours = self.gen_model.get_tours()
-        if prob is None:
-            prob = self.model.calc_prob_again()
         orig_agg = self.generation_zone_data.result_aggs
         dest_agg = self.attraction_zone_data.result_aggs
         for mode in self.modes:

--- a/Scripts/models/generation.py
+++ b/Scripts/models/generation.py
@@ -40,9 +40,6 @@ class GenerationModel:
         self.purpose = purpose
         self.param = param
 
-    def init_tours(self):
-        pass
-
     def add_tours(self):
         pass
 

--- a/Scripts/models/generation.py
+++ b/Scripts/models/generation.py
@@ -36,34 +36,34 @@ class GenerationModel:
                 Generation factor
         """
         self.resultdata = resultdata
-        self.zone_data = purpose.attraction_zone_data
+        self.zone_data = purpose.generation_zone_data
         self.purpose = purpose
         self.param = param
 
     def init_tours(self):
-        """Initialize `tours` vector to 0."""
-        self.tours = pandas.Series(
-            0.0, self.purpose.orig_zone_numbers, dtype=numpy.float32)
+        pass
 
     def add_tours(self):
-        """Generate and add tours to zone vector."""
-        shares = {
-            "has_car": self.zone_data["sh_car"],
-            "no_car": 1 - self.zone_data["sh_car"]
-        }
-        for car_availibility, b in self.param.items():
-            tours = sum(b[i]*self.zone_data[i][self.purpose.bounds] for i in b)
-            self.tours += shares[car_availibility] * tours
+        pass
 
     def get_tours(self):
-        """Get vector of tour numbers per zone.
-        
+        """Generate vector of tour numbers per zone.
+
         Returns
         -------
         numpy.ndarray
             Vector of tour numbers per zone
         """
-        return self.tours.values
+        all_tours = numpy.zeros(
+            len(self.purpose.orig_zone_numbers), dtype=numpy.float32)
+        shares = {
+            "has_car": numpy.asarray(self.zone_data["sh_car"]),
+            "no_car": 1 - numpy.asarray(self.zone_data["sh_car"])
+        }
+        for car_availibility, b in self.param.items():
+            tours = sum(b[i]*numpy.asarray(self.zone_data[i]) for i in b)
+            all_tours += shares[car_availibility] * tours
+        return all_tours
 
 class LogitTourGeneration(GenerationModel):
     """Tours are created in `model.logit.GenerationLogit."""
@@ -92,25 +92,32 @@ class LogitTourGeneration(GenerationModel):
         self.zone_data = zone_data
         self.gen_model = GenerationLogit(parameters, zone_data, bounds, resultdata)
 
-    def add_tours(self):
+    def get_tours(self):
+        """Generate vector of tour numbers per zone.
+
+        Returns
+        -------
+        numpy.ndarray
+            Vector of tour numbers per zone
+        """
         prob = self.gen_model.calc_prob()
+        all_tours = numpy.zeros(
+            len(self.purpose.orig_zone_numbers), dtype=numpy.float32)
         for nr in range(2):
             # Each combination is a tuple of tours performed during a day
-            nr_tours: pandas.Series = (nr * prob[str(nr)] * 
-                                       self.zone_data["population"])
-            self.tours += nr_tours
+            nr_tours = (nr * prob[str(nr)]
+                        * numpy.asarray(self.zone_data["population"]))
+            all_tours += nr_tours
+        return all_tours
 
 class NonHomeGeneration(GenerationModel):
     """For calculating numbers of non-home tours starting in each zone."""
 
     def add_tours(self):
-        pass
-    
-    def get_tours(self):
         """Generate vector of tour numbers from attracted source tours.
 
         Assumes that home-based tours have been assigned destinations.
-        
+
         Returns
         -------
         numpy.ndarray
@@ -121,12 +128,15 @@ class NonHomeGeneration(GenerationModel):
             b = self.param[source.name]
             for mode in source.attracted_tours:
                 mode_tours[mode] += b * source.attracted_tours[mode]
-        tours = sum(mode_tours.values())
+        self.tours = sum(mode_tours.values())
         for mode in mode_tours:
             key = f"{self.purpose.name}_parent_{mode}_share"
             self.zone_data.share[key] = pandas.Series(
-                divide(mode_tours[mode], tours), self.purpose.orig_zone_numbers)
-        return tours
+                divide(mode_tours[mode], self.tours),
+                self.purpose.orig_zone_numbers)
+
+    def get_tours(self):
+        return self.tours
 
 
 class SecDestGeneration(GenerationModel):

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -322,32 +322,6 @@ class ModeDestModel(LogitModel):
         if calc_accessibility:
             self._calc_accessibility(mode_exps, mode_expsum)
         mode_probs = self._calc_mode_prob(mode_exps, mode_expsum)
-        if mode_probs is None:
-            self._stashed_exps += [dest_exps, dest_expsums]
-            return None
-        else:
-            try:
-                self.soft_mode_probs = {
-                    mode: mode_probs[mode] for mode in self.soft_mode_exps}
-            except AttributeError:
-                pass
-            return self._calc_prob(mode_probs, dest_exps, dest_expsums)
-
-    def calc_prob_again(self) -> dict:
-        """Return matrix of choice probabilities.
-
-        First recovers basic probabilities. Then inserts individual
-        dummy variables by calling `calc_individual_prob()`.
-
-        Returns
-        -------
-        dict
-            Mode (car/transit/bike/walk) : numpy 2-d matrix
-                Choice probabilities
-        """
-        mode_exps, mode_expsum, dest_exps, dest_expsums = self._stashed_exps
-        del self._stashed_exps
-        mode_probs = self._calc_mode_prob(mode_exps, mode_expsum)
         try:
             self.soft_mode_probs = {
                 mode: mode_probs[mode] for mode in self.soft_mode_exps}
@@ -431,11 +405,7 @@ class ModeDestModel(LogitModel):
         mode_probs: defaultdict[str, list] = defaultdict(list)
         no_dummy_share = 1.0
         for dummy, modes in dummies.items():
-            try:
-                dummy_share = numpy.asarray(self.generation_zone_data[dummy])
-            except KeyError:
-                self._stashed_exps = [mode_exps, mode_expsum]
-                return None
+            dummy_share = numpy.asarray(self.generation_zone_data[dummy])
             no_dummy_share -= dummy_share
             mode_exps2 = self._calc_individual_prob(modes, dummy, mode_exps)
             mode_expsum2 = sum(mode_exps2.values())

--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -297,11 +297,6 @@ class ModeDestModel(LogitModel):
         First calculates basic probabilities. Then inserts individual
         dummy variables by calling `calc_individual_prob()`.
 
-        If model for non-home-based tours has individual dummy variables
-        representing parent tour mode choice, None will be returned,
-        because it requires parent tour demand to be calculated first.
-        In this case, `calc_prob_again` will be called later.
-
         Parameters
         ----------
         impedance : dict


### PR DESCRIPTION
The `NonHomeGeneration` model also creates `f"{self.purpose.name}_parent_{mode}_share"` zone variables needed in mode choice model. Previously they were not available in first probability calculation attempt, resulting in the complicated stashing logic in `models.logit` module. Now when generation is independent for each tour purpose, we can always do the zone variable creation before mode choice, resulting in less dead weight.

For home-based generation there is no need to calculate tour numbers in advance.