### PR TITLE
Fix park-and-ride cost

### DIFF
--- a/Scripts/assignment/datatypes/transit.py
+++ b/Scripts/assignment/datatypes/transit.py
@@ -307,16 +307,20 @@ class MixedMode(TransitMode):
     def get_matrices(self):
         transfer_penalty = (param.transfer_penalty[self.name]
                             * (self.num_board.data > 0)).astype("float32")
-        cost = self.inv_cost.data + self.board_cost.data + self.park_cost.data
-        time = self.gen_cost.data - self.vot_inv*cost - transfer_penalty
+        cost = (self.inv_cost.data
+                + self.board_cost.data
+                + self.dist_unit_cost*self.car_dist.data
+                + self.park_cost.data)
+        car_time_correction = 1.5 if "airpl" in self.name else 6.5
+        time = (self.gen_cost.data
+                - self.vot_inv*cost
+                - transfer_penalty
+                - car_time_correction*self.car_time.data)
         time[cost > 999999] = 999999
         mtxs = {"time": time, "cost": cost}
         for mtx_name in param.impedance_output:
             if mtx_name in self._matrices:
                 mtxs[mtx_name] = self._matrices[mtx_name].data
-        mtxs["cost"] += self.dist_unit_cost * self.car_dist.data
-        car_time_correction = 1.5 if "airpl" in self.name else 6.5
-        mtxs["time"] -= car_time_correction * self.car_time.data
         self._soft_release_matrices()
         return mtxs
 

--- a/Scripts/assignment/datatypes/transit.py
+++ b/Scripts/assignment/datatypes/transit.py
@@ -305,11 +305,19 @@ class MixedMode(TransitMode):
         self.emme_scenario.publish_network(network)
 
     def get_matrices(self):
-        car_cost = self.dist_unit_cost * self.car_dist.data
-        mtxs = TransitMode.get_matrices(self)
-        mtxs["cost"] += car_cost
+        transfer_penalty = (param.transfer_penalty[self.name]
+                            * (self.num_board.data > 0)).astype("float32")
+        cost = self.inv_cost.data + self.board_cost.data + self.park_cost.data
+        time = self.gen_cost.data - self.vot_inv*cost - transfer_penalty
+        time[cost > 999999] = 999999
+        mtxs = {"time": time, "cost": cost}
+        for mtx_name in param.impedance_output:
+            if mtx_name in self._matrices:
+                mtxs[mtx_name] = self._matrices[mtx_name].data
+        mtxs["cost"] += self.dist_unit_cost * self.car_dist.data
         car_time_correction = 1.5 if "airpl" in self.name else 6.5
         mtxs["time"] -= car_time_correction * self.car_time.data
+        self._soft_release_matrices()
         return mtxs
 
     def _save_link_results(self, network):

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -187,14 +187,16 @@ class Purpose:
                     except KeyError:
                         pass
             if "vrk" in self.impedance_share[mode] and mode != "walk":
+                if mode in mixed_mode_classes:
+                    # Remove default parking cost and add cost based on tour duration
+                    park_time = (cost.tour_duration[mode][self.name]
+                                 / cost.tour_duration[mode]["avg"])
+                    day_imp[mode]["cost"] += (day_imp[mode].pop("park_cost")
+                                              * (park_time-1))
                 vot = cost.value_of_time[mode_impedance[mode]]
                 day_imp[mode]["gen_cost"] = (day_imp[mode].pop("cost")
                                              + vot*day_imp[mode].pop("time")/60)
                 log.info(f"Generalized cost calculated for {self.name} {mode}.")
-            if mode in mixed_mode_classes:
-                day_imp[mode]["park_cost"] = (day_imp[mode]["park_cost"]
-                                              * cost.tour_duration[mode][self.name]
-                                              / cost.tour_duration[mode]["avg"])
         return day_imp
 
 def new_tour_purpose(*args):


### PR DESCRIPTION
This fixes handling of parking cost in park-and-ride modes both on assignment and demand side.

Assignment side: Add parking cost to cost matrix. This means that time matrix, which is calculated by removing cost from generalized cost, changes as well.

Demand side: Add parking cost to generalized cost where it should be.