### PR TITLE
Remove `parameters.assignment.assignment_classes`

### DIFF
--- a/Scripts/assignment/departure_time.py
+++ b/Scripts/assignment/departure_time.py
@@ -76,7 +76,7 @@ class DepartureTimeModel:
         """
         try:
             self.old_car_demand = next(iter(self.demand.values()))["car"]
-        except FileNotFoundError:
+        except:  # In MockAssignmentModel, this can fail for various reasons
             pass
         n = self.nr_zones
         for ap in self.assignment_periods:

--- a/Scripts/datatypes/purpose.py
+++ b/Scripts/datatypes/purpose.py
@@ -11,7 +11,6 @@ import utils.log as log
 import parameters.zone as param
 import models.logit as logit
 from parameters.assignment import (
-    assignment_classes,
     intermodals,
     mixed_mode_classes,
     mode_impedance

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -394,23 +394,6 @@ intermodals = {
     "transit": ["pt_car_acc", "pt_taxi_acc", "pt_taxi_egr"],
     "airplane": ["airpl_car_acc", "airpl_car_egr"],
 }
-assignment_classes = {
-    "hb_work": "work",
-    "hb_edu_basic": "work",
-    "hb_edu_student": "work",
-    "hb_grocery": "leisure",
-    "hb_other_shop": "leisure",
-    "hb_leisure": "leisure",
-    "hb_escort": "leisure",
-    "hb_sport": "leisure",
-    "hb_visit": "leisure",
-    "hb_leisure_overnight": "leisure",
-    "hb_business": "work",
-    "wb_business": "work",
-    "wb_other": "leisure",
-    "ob_other": "leisure",
-    "external": "leisure",
-}
 main_mode = 'h'
 bike_mode = 'f'
 assignment_modes = {

--- a/Scripts/travel_iteration.py
+++ b/Scripts/travel_iteration.py
@@ -112,11 +112,9 @@ class ModelSystem:
         self.resultdata = ResultsData(results_path)
         self.resultmatrices = MatrixData(results_path / "Matrices" / submodel)
         parameters_path = Path(__file__).parent / "parameters" / "demand"
-        home_based_work_purposes = []
-        home_based_leisure_purposes = []
+        home_based_purposes = []
         sec_dest_purposes = []
-        other_work_purposes = []
-        other_leisure_purposes = []
+        other_purposes = []
         purpose_names = []
         for file in parameters_path.glob("*.json"):
             specification = json.loads(file.read_text("utf-8"))
@@ -142,23 +140,15 @@ class ModelSystem:
                 if isinstance(purpose, SecDestPurpose):
                     sec_dest_purposes.append(purpose)
                 elif purpose.orig == "home":
-                    if param.assignment_classes[purpose.name] == "work":
-                        home_based_work_purposes.append(purpose)
-                    else:
-                        home_based_leisure_purposes.append(purpose)
+                    home_based_purposes.append(purpose)
                 else:
-                    if param.assignment_classes[purpose.name] == "work":
-                        other_work_purposes.append(purpose)
-                    else:
-                        other_leisure_purposes.append(purpose)
+                    other_purposes.append(purpose)
         if len(purpose_names) != len(set(purpose_names)):
             msg = f"Duplicate tour purposes in demand parameters."
             log.error(msg)
             raise ValueError(msg)
         self.dm = self._init_demand_model(
-            home_based_work_purposes + other_work_purposes
-            + home_based_leisure_purposes + other_leisure_purposes
-            + sec_dest_purposes)
+            home_based_purposes + other_purposes + sec_dest_purposes)
         self.travel_modes = {mode: True for purpose in self.dm.tour_purposes
             for mode in purpose.modes}  # Dict instead of set, to preserve order
         self.ass_classes = set()


### PR DESCRIPTION
With work-leisure split removed, purpose sorting can be simplified and `parameters.assignment.assignment_classes` removed altogether.

Bonus: Fix failing matrix lookup in `MockAssignmentModel` (especially when mode names change).