### PR TITLE
Add vans based on car volumes only

### DIFF
--- a/Scripts/assignment/departure_time.py
+++ b/Scripts/assignment/departure_time.py
@@ -171,8 +171,6 @@ class DepartureTimeModel:
             car_demand = mtx["car"][0:n, 0:n]
             share = param.demand_share["freight"]["van"][time_period]
             self._add_2d_demand(share, "van", time_period, car_demand, (0, 0))
-            self._add_2d_demand(
-                (1, 0), "van", time_period, mtx["truck"][0:n, 0:n], (0, 0))
 
 
 class DirectDepartureTimeModel (DepartureTimeModel):

--- a/Scripts/parameters/departure_time.py
+++ b/Scripts/parameters/departure_time.py
@@ -17,11 +17,12 @@ demand_share: Dict[str,Dict[str,Any]] = {
             "iht": (0.066, 0),
         },
         "van": {
-            # As shares of car traffic
-            # On top of this, the trucks sum is added
-            "aht": (0.054, 0),
-            "pt": (0.07, 0),
-            "iht": (0.044, 0),
+            # Vans are calculated by multiplying car demand with this share.
+            # This is a ratio of total mileage by vans / car driver (Statfi).
+            # Peaks are calculated by assuming that vans have even demand distribution through day.
+            "aht": (0.10, 0),
+            "pt": (0.17, 0),
+            "iht": (0.08, 0),
         },
     },
     "external": {


### PR DESCRIPTION
* Add vans based on car volumes only as truck traffic development is ongoing.
* Update rates based on Statistics Finland 2016 summary statistics on van and car mileage. 
* Assumed that vans have even time distribution and car peaks follow HLT 2016 data.
* Calculation of new rates is stored in Sharepoint `05_Henkilöliikenne / Pakettiautot`.