### PR TITLE
Hotfix: Add sec_dest_rates as empty dictionary to ExternalPurpose

### DIFF
--- a/Scripts/demand/external.py
+++ b/Scripts/demand/external.py
@@ -20,3 +20,4 @@ class ExternalPurpose:
         bounds = slice(*zone_numbers.searchsorted(purpose_areas["all"]))
         self.bounds = bounds
         self.dest_interval = bounds
+        self.sec_dest_rates = {}

--- a/Scripts/dev-config.json
+++ b/Scripts/dev-config.json
@@ -1,5 +1,5 @@
 {
-    "LEM_VERSION": "v0.0.1",
+    "LEM_VERSION": "v0.9.1",
     "LOG_LEVEL": "INFO",
     "LOG_FORMAT": "TEXT",
     "PROJECT_NAME": "testproject",


### PR DESCRIPTION
This fixes a bug where the model run fails when importing long trips in short trips run.