### PR TITLE
Add result export of household car ownership

### DIFF
--- a/Scripts/demand/trips.py
+++ b/Scripts/demand/trips.py
@@ -84,6 +84,13 @@ class DemandModel:
                               + zd["sh_cars1_hh2"]
                               + zd["sh_cars2_hh2"])
         result = {"cars": numpy.zeros_like(zd["population"])}
+        hh_cars1_adult1 = zd["sh_hh1_lic1"] * prob["hh1_lic1"]["1"]
+        result["sh_cars1_hh1"] = (zd["sh_hh_1_adult_no_children"]
+                                  * hh_cars1_adult1)
+        result["sh_cars1_hh2"] = (zd["sh_hh_1_adult_children"]*hh_cars1_adult1
+                                  + zd["sh_hh2_lic1"]*prob["hh2_lic1"]["1"]
+                                  + zd["sh_hh2_lic2"]*prob["hh2_lic2"]["1"])
+        result["sh_cars2_hh2"] = zd["sh_hh2_lic2"]*prob["hh2_lic2"]["2"]
         for n_cars in range(3):
             result[f"sh_cars{n_cars}"] = numpy.zeros_like(zd["population"])
             for hh_type in prob:


### PR DESCRIPTION
We need to print household-type-specific car-ownership shares to be able to use them in the long-distance model.

Problem: In the statistics we have "sh_carsx_hh3" as a separate group, but not in the car-ownership model. Could we merge hh2 and hh3 in the input zone data to solve this?