### PR TITLE
Calc domestic leg's vehicles

### DIFF
--- a/Scripts/tests/unit/test_freight_demand.py
+++ b/Scripts/tests/unit/test_freight_demand.py
@@ -64,8 +64,9 @@ class FreightModelTest(unittest.TestCase):
         impedance["semi_trailer"] = impedance["truck"]
         impedance["trailer_truck"] = impedance["truck"]
 
-        trade_demand, fin_borders = self.run_trade_route_choice(zonedata, resultdata, 
-                                                                costdata, impedance)
+        # Run test foreign trade choice model
+        trade_demand, foreign_purposes, fin_borders = self.run_trade_route_choice(
+            zonedata, resultdata, costdata, impedance)
         for mtx_type in impedance.keys():
             for ass_class, mtx in impedance[mtx_type].items():
                 impedance[mtx_type][ass_class] = mtx[:zonedata.nr_zones, :zonedata.nr_zones]
@@ -73,25 +74,41 @@ class FreightModelTest(unittest.TestCase):
                                    resultdata, costdata["freight"])
         self.assertEqual(len(purposes), 2)
 
-        total_demand = {mode: numpy.zeros_like(impedance["truck"]["cost"])
+        total_demand = {mode : numpy.zeros_like(impedance["truck"]["cost"])
                         for mode in param.truck_classes}
         iterations = 1
         mapping = {zone: idx for idx, zone in enumerate(zonedata.zone_numbers)}
+        
+        # Run test domestic demand model
         for purpose in purposes.values():
             demand = purpose.calc_traffic(impedance)
             demand_trade = purpose.calc_trade_mode_share(demand, trade_demand, fin_borders)
             costs = purpose.get_costs(impedance)
             self._assert_calc_demand_results(demand, costs)
+            
+            # Calculate test vehicles
             aux_demand = {
                 mode: numpy.ones_like(impedance["truck"]["cost"])
                 for mode in demand if mode != "truck"
             }
+            ton_demand = demand["truck"] + sum(aux_demand.values())
+            vehicles = {
+                model_type: {mode : numpy.zeros_like(impedance["truck"]["cost"])
+                             for mode in param.truck_classes}
+                for model_type in ("domestic", "foreign")
+            }
             for mode in param.truck_classes:
-                ton_demand = demand["truck"] + sum(aux_demand.values())
-                total_demand[mode] += purpose.calc_vehicles(ton_demand, mode)
+                vehicles["domestic"][mode] += purpose.calc_vehicles(ton_demand, mode)
+                for foreign_purpose in demand_trade:
+                    vehicles["foreign"][mode] += foreign_purposes[foreign_purpose].calc_vehicles(
+                        demand_trade[foreign_purpose]["truck"], mode)
+                total_demand[mode] += vehicles["domestic"][mode] + vehicles["foreign"][mode]
+            self._assert_calc_vehicle_results(vehicles, purpose.name)
             write_purpose_summary(purpose, demand, aux_demand, impedance, resultdata)
             write_zone_summary(purpose.name, zonedata.zone_numbers, demand, resultdata)
             write_domestic_leg_summary(demand_trade, impedance, resultdata)
+            
+            # Calculate test logistics demand
             if purpose.route_params and iterations > 0:
                 demand_truck, per_route = purpose.run_logistics_module(demand["truck"],
                                                                        impedance, mapping, 
@@ -108,7 +125,7 @@ class FreightModelTest(unittest.TestCase):
                 elif purpose.name == "kummuo":
                     self.assertAlmostEqual(detour_total, 76.215096, places=3)
                     self.assertAlmostEqual(direct_total, 15706.936, places=3)
-
+        
         write_vehicle_summary(total_demand, impedance, resultdata)
         resultdata.flush()
 
@@ -145,7 +162,7 @@ class FreightModelTest(unittest.TestCase):
                                fin_border, cluster_border, resultdata)
             trade_demand[purpose.name] = demand
         resultdata.flush()
-        return trade_demand, list(fin_border.values())
+        return trade_demand, purposes, list(fin_border.values())
 
     def _assert_calc_demand_results(self, demand, costs):
         for mode in demand:
@@ -154,3 +171,21 @@ class FreightModelTest(unittest.TestCase):
                 self.assertTrue(numpy.isfinite(costs[mode]["cost"]).all())
             else:
                 self.assertTrue(numpy.isfinite(costs[mode]["cost"]).any())
+
+    def _assert_calc_vehicle_results(self, vehicles, purpose_name):
+        dom_vehicles = vehicles["domestic"]
+        for_vehicles = vehicles["foreign"] 
+        if purpose_name == "kemlaa":
+            self.assertAlmostEqual(numpy.sum(dom_vehicles["truck"]), 2.107039, places=3)
+            self.assertAlmostEqual(numpy.sum(for_vehicles["truck"]), 0.032649778, places=3)
+            self.assertAlmostEqual(numpy.sum(dom_vehicles["semi_trailer"]), 1.2128458, places=3)
+            self.assertAlmostEqual(numpy.sum(for_vehicles["semi_trailer"]), 0.05011665, places=3)
+            self.assertAlmostEqual(numpy.sum(dom_vehicles["trailer_truck"]), 1.0033518, places=3)
+            self.assertAlmostEqual(numpy.sum(for_vehicles["trailer_truck"]), 0.031095028, places=3)
+        elif purpose_name == "kummuo":
+            self.assertAlmostEqual(numpy.sum(dom_vehicles["truck"]), 2.5090113, places=3)
+            self.assertAlmostEqual(numpy.sum(for_vehicles["truck"]), 0.0, places=3)
+            self.assertAlmostEqual(numpy.sum(dom_vehicles["semi_trailer"]), 1.4442277, places=3)
+            self.assertAlmostEqual(numpy.sum(for_vehicles["semi_trailer"]), 0.0, places=3)
+            self.assertAlmostEqual(numpy.sum(dom_vehicles["trailer_truck"]), 1.1947672, places=3)
+            self.assertAlmostEqual(numpy.sum(for_vehicles["trailer_truck"]), 0.0, places=3)

--- a/Scripts/valma_freight.py
+++ b/Scripts/valma_freight.py
@@ -44,9 +44,9 @@ def main(args):
     resultmatrices = MatrixData(result_data_folder / "Matrices" / "koko_suomi")
     costdata = json.loads(cost_data_file.read_text("utf-8"))
     
-    # Set purposes and fetch impedances
-    purposes = create_purposes(parameters_path / "foreign", zonedata, 
-                               resultdata, costdata["freight"])
+    # Set foreign purposes and fetch impedances
+    foreign_purposes = create_purposes(parameters_path / "foreign", zonedata, 
+                                       resultdata, costdata["freight"])
     purposes_to_assign = [purpose for purpose in list(commodity_conversion)
                           if purpose in args.specify_commodity_names]
     ass_model.prepare_freight_network(
@@ -56,7 +56,7 @@ def main(args):
                                zonedata.all_zone_numbers, zonedata.zone_numbers)
     impedance = ass_model.freight_network.assign()
     
-    log.info("Read marine ship impedances from network")
+    log.info("Reads marine ship impedances from network")
     trade_demand = {}
     marine_export = ass_model.freight_network.read_ship_impedances(True)
     marine_import = ass_model.freight_network.read_ship_impedances(False)
@@ -71,7 +71,7 @@ def main(args):
     fin_border_ids = list(marine_export[1].values())
     marine_export, marine_import = None, None
 
-    # prepare domestic model by splicing impedances and initializing final demand matrix 
+    # Prepare domestic model by splicing impedances and initializing final demand matrix 
     for ass_class in list(impedance):
         for mtx_type, mtx in impedance[ass_class].items():
             impedance[ass_class][mtx_type] = mtx[:zonedata.nr_zones, :zonedata.nr_zones]
@@ -84,7 +84,6 @@ def main(args):
     for purpose in purposes.values():
         log.info(f"Calculating demand for purpose: {purpose.name}")
         demand = purpose.calc_traffic(impedance)
-        demand_trade = purpose.calc_trade_mode_share(demand, trade_demand, fin_border_ids)
         if purpose.route_params and args.logistics_iterations > 0:
             demand["truck"], _ = purpose.run_logistics_module(demand["truck"], impedance, 
                                                               ass_model.mapping, 
@@ -95,14 +94,21 @@ def main(args):
             store_demand.store(mode, demand[mode], omx_filename, purpose.name)
         if purpose.name in args.specify_commodity_names:
             ass_model.freight_network.save_network_volumes(purpose.name)
+        
+        # Calc aux tons and transform tons to vehicles
         ass_model.freight_network.output_traversal_matrix(set(demand), resultdata.path)
         aux_demand = transform_traversal_data(resultdata.path, zonedata.zone_numbers)
+        domestic_tons = demand["truck"] + sum(aux_demand.values())
+        dom_leg_tons = purpose.calc_trade_mode_share(
+            demand, trade_demand, fin_border_ids)
         for mode in param.truck_classes:
-            ton_demand = demand["truck"] + sum(aux_demand.values())
-            total_demand[mode] += purpose.calc_vehicles(ton_demand, mode)
+            total_demand[mode] += purpose.calc_vehicles(domestic_tons, mode)
+            for foreign_purpose in dom_leg_tons:
+                total_demand[mode] += foreign_purposes[foreign_purpose].calc_vehicles(
+                    dom_leg_tons[foreign_purpose]["truck"], mode)
         write_purpose_summary(purpose, demand, aux_demand, impedance, resultdata)
         write_zone_summary(purpose.name, zonedata.zone_numbers, demand, resultdata)
-        write_domestic_leg_summary(demand_trade, impedance, resultdata)
+        write_domestic_leg_summary(dom_leg_tons, impedance, resultdata)
     write_vehicle_summary(total_demand, impedance, resultdata)
     resultdata.flush()
     


### PR DESCRIPTION
Adds tons to vehicles calculation for foreign model's domestic leg. Because vehicle shares are different in foreign model cost specifications, don't override foreign purposes with domestic purposes.