### PR TITLE
Remove extra coefficients from visit tours utility

### DIFF
--- a/Scripts/parameters/demand/hb_visit.json
+++ b/Scripts/parameters/demand/hb_visit.json
@@ -177,9 +177,7 @@
             }
         },
         "bike": {
-            "attraction": {
-                "dist*within_zone": -0.3191
-            },
+            "attraction": {},
             "impedance": {
                 "dist": -0.3191
             },
@@ -196,9 +194,7 @@
             }
         },
         "walk": {
-            "attraction": {
-                "dist*within_zone": -0.7632
-            },
+            "attraction": {},
             "impedance": {
                 "dist": -0.7632
             },

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -57,7 +57,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.3910775322505153)
+            0.3903572506732479)
         
         print("Model system test done")
 


### PR DESCRIPTION
Separate within zone parameters should have been removed in #402 as distance is added to LOS matrix diagonal.