### PR TITLE
Update diagonal impedances

### DIFF
--- a/Scripts/tests/unit/test_freight_demand.py
+++ b/Scripts/tests/unit/test_freight_demand.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-from pathlib import Path
 import json
 import numpy
 import unittest
 import openmatrix as omx
+from copy import deepcopy
 
 import parameters.assignment as param
 from datahandling.resultdata import ResultsData
 from datahandling.zonedata import FreightZoneData
 from utils.freight_utils import (
-    create_purposes, write_leg2_summary, write_purpose_summary, 
+    create_purposes, write_leg2_summary, write_purpose_summary, update_diagonal_cost,
     write_zone_summary, write_vehicle_summary, write_domestic_leg_summary
 )
 from tests.integration.test_data_handling import (
@@ -61,8 +61,9 @@ class FreightModelTest(unittest.TestCase):
                 "canal_cost": numpy.zeros([len(ZONE_NUMBERS), len(ZONE_NUMBERS)])
             }
         }
-        impedance["semi_trailer"] = impedance["truck"]
-        impedance["trailer_truck"] = impedance["truck"]
+        impedance["semi_trailer"] = deepcopy(impedance["truck"])
+        impedance["trailer_truck"] = deepcopy(impedance["truck"])
+        impedance = update_diagonal_cost(impedance)
 
         # Run test foreign trade choice model
         trade_demand, foreign_purposes, fin_borders = self.run_trade_route_choice(
@@ -120,11 +121,11 @@ class FreightModelTest(unittest.TestCase):
                 detour_total = numpy.sum(per_route[:-1])
                 direct_total = per_route[-1]
                 if purpose.name == "kemlaa":
-                    self.assertAlmostEqual(detour_total, 50.635654, places=3)
-                    self.assertAlmostEqual(direct_total, 12883.39, places=3)
+                    self.assertAlmostEqual(detour_total, 19.52376, places=3)
+                    self.assertAlmostEqual(direct_total, 12913.464, places=3)
                 elif purpose.name == "kummuo":
-                    self.assertAlmostEqual(detour_total, 81.766624, places=3)
-                    self.assertAlmostEqual(direct_total, 15670.479, places=3)
+                    self.assertAlmostEqual(detour_total, 26.133245, places=3)
+                    self.assertAlmostEqual(direct_total, 15725.467, places=3)
 
         write_vehicle_summary(total_demand, impedance, resultdata)
         resultdata.flush()

--- a/Scripts/utils/freight_utils.py
+++ b/Scripts/utils/freight_utils.py
@@ -2,9 +2,10 @@ import json
 import numpy
 from pathlib import Path
 from typing import Dict
-from pandas import DataFrame, concat
+from pandas import DataFrame
 
 import utils.log as log
+from parameters.assignment import truck_classes
 from datatypes.purpose import FreightPurpose
 from datahandling.zonedata import FreightZoneData
 from datahandling.resultdata import ResultsData
@@ -53,6 +54,35 @@ def create_purposes(parameters_path: Path, zonedata: FreightZoneData,
                                                             zone_data, resultdata,
                                                             purpose_cost)
     return purposes
+
+def update_diagonal_cost(impedance: dict) -> dict:
+    """Updates diagonal (own zone) impedance values
+
+    Parameters
+    ----------
+    impedance : dict
+        Mode (truck/train/...) : dict
+            Type (cost/time/dist...) : numpy 2d matrix
+    
+    Returns
+    -------
+    dict
+        Mode (truck/train/...) : dict
+            Type (cost/time/dist...) : numpy 2d matrix
+    """
+    for mode in impedance:
+        if mode in truck_classes:
+            diag_values = {
+                imp_type: numpy.min(
+                    numpy.where(impedance[mode][imp_type] > 0, 
+                    impedance[mode][imp_type], numpy.inf), axis=1)
+                for imp_type in ("cost", "dist")
+            }
+        else:
+            diag_values = {mtx: numpy.inf for mtx in ("time", "aux_cost")}
+        for imp_type in diag_values:
+            numpy.fill_diagonal(impedance[mode][imp_type], diag_values[imp_type])
+    return impedance
 
 def write_leg2_summary(purpose: FreightPurpose, demand: dict, 
                        _, fin_border_ids: dict, cluster_border_ids: dict,

--- a/Scripts/valma_freight.py
+++ b/Scripts/valma_freight.py
@@ -14,7 +14,7 @@ from assignment.emme_bindings.emme_project import EmmeProject
 from datahandling.matrixdata import MatrixData
 
 from utils.freight_utils import (
-    create_purposes, StoreDemand,
+    create_purposes, StoreDemand, update_diagonal_cost,
     write_leg2_summary, write_domestic_leg_summary, write_purpose_summary, 
     write_zone_summary, write_vehicle_summary
 )
@@ -55,7 +55,8 @@ def main(args):
     store_demand = StoreDemand(ass_model.freight_network, resultmatrices, 
                                zonedata.all_zone_numbers, zonedata.zone_numbers)
     impedance = ass_model.freight_network.assign()
-    
+    impedance = update_diagonal_cost(impedance)
+
     log.info("Reads marine ship impedances from network")
     trade_demand = {}
     marine_export = ass_model.freight_network.read_ship_impedances(True)


### PR DESCRIPTION
Dev is currently missing diagonal (own zone) impedances which are added in this PR. In freight model result testing we have defined truck modes' diagonal values to be the impedance to closest neighboring centroid. Transit modes diagonal values are always inf.