### PR TITLE
Add sqrt density to car ownership model

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -124,7 +124,8 @@ class ZoneData:
 
         self["pop_density"] = divide(data["population"], data["land_area"])
         self["log_pop_density"] = numpy.log(self["pop_density"]+1)
-
+        self["sqrt_pop_density"] = numpy.sqrt(self["pop_density"])
+        
         # Two-way intrazonal distances from building distances
         self["dist_walk"] = data["intra_dist_walk"] * 2
         self["dist_bike"] = data["intra_dist_bike"] * 2

--- a/Scripts/parameters/car.py
+++ b/Scripts/parameters/car.py
@@ -24,7 +24,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_1_adult_children": 0,
             },
             "calibration": {
-                "constant": 0
+                "constant": 0.295158762
             }
         },
         "1": {
@@ -47,7 +47,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_1_adult_children": 0.530891,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": -0.09826214
             },
         }
     },
@@ -70,7 +70,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0,
             },
             "calibration": {
-                "constant": 0
+                "constant": 0.432910651
             }
         },
         "1": {
@@ -93,7 +93,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0.197250,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": -0.05476665
             }
         },
     },
@@ -116,7 +116,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0,
             },
             "calibration": {
-                "constant": 0
+                "constant": -0.35784365
             }
         },
         "1": {
@@ -139,7 +139,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0.379870,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": -0.01644901
             }
         },
         "2": {
@@ -162,7 +162,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 1.133864+0.573108,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": 0.061056609
             }
         }
     }

--- a/Scripts/parameters/car.py
+++ b/Scripts/parameters/car.py
@@ -28,26 +28,26 @@ car_ownership = {
             }
         },
         "1": {
-            "constant": 3.661863,
+            "constant": 3.065065,
             "generation": {
-                "hb_leisure_sustainable": -0.653260,
+                "sqrt_pop_density": -0.022965,
             },
             "individual_dummy": {
-                "sh_income_0_19*sh_hh_1_adult_no_children": -1.488385,
-                "sh_income_20_39*sh_hh_1_adult_no_children": -0.500473,
+                "sh_income_0_19*sh_hh_1_adult_no_children": -1.553698,
+                "sh_income_20_39*sh_hh_1_adult_no_children": -0.580916,
                 "sh_income_40_59*sh_hh_1_adult_no_children": 0,
                 "sh_income_60_79*sh_hh_1_adult_no_children": 0,
                 "sh_income_80_99*sh_hh_1_adult_no_children": 0,
                 "sh_income_100_*sh_hh_1_adult_no_children": 0,
-                "sh_income_0_19*sh_hh_1_adult_children": -1.488385+0.528040,
-                "sh_income_20_39*sh_hh_1_adult_children": -0.500473+0.528040,
-                "sh_income_40_59*sh_hh_1_adult_children": 0.528040,
-                "sh_income_60_79*sh_hh_1_adult_children": 0.528040,
-                "sh_income_80_99*sh_hh_1_adult_children": 0.528040,
-                "sh_income_100_*sh_hh_1_adult_children": 0.528040,
+                "sh_income_0_19*sh_hh_1_adult_children": -1.553698+0.530891,
+                "sh_income_20_39*sh_hh_1_adult_children": -0.580916+0.530891,
+                "sh_income_40_59*sh_hh_1_adult_children": 0.530891,
+                "sh_income_60_79*sh_hh_1_adult_children": 0.530891,
+                "sh_income_80_99*sh_hh_1_adult_children": 0.530891,
+                "sh_income_100_*sh_hh_1_adult_children": 0.530891,
             },
             "calibration": {
-                "constant": -0.5908751
+                "constant": 0.0
             },
         }
     },
@@ -74,26 +74,26 @@ car_ownership = {
             }
         },
         "1": {
-            "constant": 5.321504,
+            "constant": 3.899001,
             "generation": {
-                "hb_leisure_sustainable": -0.869877,
+                "sqrt_pop_density": -0.023521,
             },
             "individual_dummy": {
-                "sh_income_0_19*sh_hh_2_adults_no_children": -1.833297,
-                "sh_income_20_39*sh_hh_2_adults_no_children": -0.673249,
+                "sh_income_0_19*sh_hh_2_adults_no_children": -1.608033,
+                "sh_income_20_39*sh_hh_2_adults_no_children": -0.541490,
                 "sh_income_40_59*sh_hh_2_adults_no_children": 0,
                 "sh_income_60_79*sh_hh_2_adults_no_children": 0,
                 "sh_income_80_99*sh_hh_2_adults_no_children": 0,
                 "sh_income_100_*sh_hh_2_adults_no_children": 0,
-                "sh_income_0_19*sh_hh_2_adults_children": -1.833297+0.179828,
-                "sh_income_20_39*sh_hh_2_adults_children": -0.673249+0.179828,
-                "sh_income_40_59*sh_hh_2_adults_children": 0.179828,
-                "sh_income_60_79*sh_hh_2_adults_children": 0.179828,
-                "sh_income_80_99*sh_hh_2_adults_children": 0.179828,
-                "sh_income_100_*sh_hh_2_adults_children": 0.179828,
+                "sh_income_0_19*sh_hh_2_adults_children": -1.608033+0.197250,
+                "sh_income_20_39*sh_hh_2_adults_children": -0.541490+0.197250,
+                "sh_income_40_59*sh_hh_2_adults_children": 0.197250,
+                "sh_income_60_79*sh_hh_2_adults_children": 0.197250,
+                "sh_income_80_99*sh_hh_2_adults_children": 0.197250,
+                "sh_income_100_*sh_hh_2_adults_children": 0.197250,
             },
             "calibration": {
-                "constant": -0.6268949
+                "constant": 0.0
             }
         },
     },
@@ -120,49 +120,49 @@ car_ownership = {
             }
         },
         "1": {
-            "constant": 4.778818,
+            "constant": 4.015710,
             "generation": {
-                "hb_leisure_sustainable": -0.694607,
+                "sqrt_pop_density": -0.020883,
             },
             "individual_dummy": {
-                "sh_income_0_19*sh_hh_2_adults_no_children": -1.657740,
-                "sh_income_20_39*sh_hh_2_adults_no_children": -0.238010,
+                "sh_income_0_19*sh_hh_2_adults_no_children": -1.663979,
+                "sh_income_20_39*sh_hh_2_adults_no_children": -0.225171,
                 "sh_income_40_59*sh_hh_2_adults_no_children": 0,
                 "sh_income_60_79*sh_hh_2_adults_no_children": 0,
                 "sh_income_80_99*sh_hh_2_adults_no_children": 0,
                 "sh_income_100_*sh_hh_2_adults_no_children": 0,
-                "sh_income_0_19*sh_hh_2_adults_children": -1.657740+0.397982,
-                "sh_income_20_39*sh_hh_2_adults_children": -0.238010+0.397982,
-                "sh_income_40_59*sh_hh_2_adults_children": 0.397982,
-                "sh_income_60_79*sh_hh_2_adults_children": 0.397982,
-                "sh_income_80_99*sh_hh_2_adults_children": 0.397982,
-                "sh_income_100_*sh_hh_2_adults_children": 0.397982,
+                "sh_income_0_19*sh_hh_2_adults_children": -1.663979+0.379870,
+                "sh_income_20_39*sh_hh_2_adults_children": -0.225171+0.379870,
+                "sh_income_40_59*sh_hh_2_adults_children": 0.379870,
+                "sh_income_60_79*sh_hh_2_adults_children": 0.379870,
+                "sh_income_80_99*sh_hh_2_adults_children": 0.379870,
+                "sh_income_100_*sh_hh_2_adults_children": 0.379870,
             },
             "calibration": {
-                "constant": 0.0899837
+                "constant": 0.0
             }
         },
         "2": {
-            "constant": 5.677953,
+            "constant": 5.160160,
             "generation": {
-                "hb_leisure_sustainable": -1.074284,
+                "sqrt_pop_density": -0.055125,
             },
             "individual_dummy": {
-                "sh_income_0_19*sh_hh_2_adults_no_children": -2.824242,
-                "sh_income_20_39*sh_hh_2_adults_no_children": -0.947093,
+                "sh_income_0_19*sh_hh_2_adults_no_children": -2.635365,
+                "sh_income_20_39*sh_hh_2_adults_no_children": -0.866118,
                 "sh_income_40_59*sh_hh_2_adults_no_children": 0,
-                "sh_income_60_79*sh_hh_2_adults_no_children": 0.331296,
-                "sh_income_80_99*sh_hh_2_adults_no_children": 0.535889,
-                "sh_income_100_*sh_hh_2_adults_no_children": 0.959502,
-                "sh_income_0_19*sh_hh_2_adults_children": -2.824242+0.650635,
-                "sh_income_20_39*sh_hh_2_adults_children": -0.947093+0.650635,
-                "sh_income_40_59*sh_hh_2_adults_children": 0.650635,
-                "sh_income_60_79*sh_hh_2_adults_children": 0.331296+0.650635,
-                "sh_income_80_99*sh_hh_2_adults_children": 0.535889+0.650635,
-                "sh_income_100_*sh_hh_2_adults_children": 0.959502+0.650635,
+                "sh_income_60_79*sh_hh_2_adults_no_children": 0.363252,
+                "sh_income_80_99*sh_hh_2_adults_no_children": 0.590681,
+                "sh_income_100_*sh_hh_2_adults_no_children": 1.133864,
+                "sh_income_0_19*sh_hh_2_adults_children": -2.635365+0.573108,
+                "sh_income_20_39*sh_hh_2_adults_children": -0.866118+0.573108,
+                "sh_income_40_59*sh_hh_2_adults_children": 0.573108,
+                "sh_income_60_79*sh_hh_2_adults_children": 0.363252+0.573108,
+                "sh_income_80_99*sh_hh_2_adults_children": 0.590681+0.573108,
+                "sh_income_100_*sh_hh_2_adults_children": 1.133864+0.573108,
             },
             "calibration": {
-                "constant": 0.0381344
+                "constant": 0.0
             }
         }
     }

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -57,7 +57,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.32763868808974883)
+            0.35971302918793086)
         
         print("Model system test done")
 

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -57,7 +57,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.35971302918793086)
+            0.3573402536266074)
         
         print("Model system test done")
 


### PR DESCRIPTION
-Replace accessibility in car ownership model with sqrt pop density
-Update car ownership model parameters and calibrate it
-Update mode share for tests