### PR TITLE
Omit accessibility export for external travel groups

### DIFF
--- a/Scripts/models/logit.py
+++ b/Scripts/models/logit.py
@@ -51,6 +51,7 @@ class LogitModel:
         self.dest_choice_param: Dict[str, Dict[str, Any]] = parameters["destination_choice"]
         self.mode_choice_param: Optional[Dict[str, Dict[str, Any]]] = parameters["mode_choice"]
         self.distance_boundary = parameters["distance_boundaries"]
+        self.accessibility: Dict[str, pandas.Series] = {}
 
     def calc_mode_prob(self, impedance: Dict[str, numpy.ndarray]):
         expsum, mode_exps = self._calc_mode_utils(impedance)

--- a/Scripts/travel_iteration.py
+++ b/Scripts/travel_iteration.py
@@ -433,8 +433,6 @@ class ModelSystem:
 
     def _export_accessibility(self):
         for purpose in self.dm.tour_purposes:
-            if purpose.name == "hb_abroad_other":
-                continue
             for logsum in purpose.model.accessibility.values():
                 self.resultdata.print_data(logsum, f"accessibility.txt")
     

--- a/Scripts/travel_iteration.py
+++ b/Scripts/travel_iteration.py
@@ -433,6 +433,8 @@ class ModelSystem:
 
     def _export_accessibility(self):
         for purpose in self.dm.tour_purposes:
+            if purpose.name == "hb_abroad_other":
+                continue
             for logsum in purpose.model.accessibility.values():
                 self.resultdata.print_data(logsum, f"accessibility.txt")
     


### PR DESCRIPTION
Fixes a fatal error when trying to export accessibility values for external travel groups (hb_abroad_other) with no destination choice model.