### PR TITLE
Set car driver unavailable for under 18 years old

### DIFF
--- a/Scripts/datahandling/zonedata.py
+++ b/Scripts/datahandling/zonedata.py
@@ -87,6 +87,7 @@ class ZoneData:
             0.5, self.zone_numbers, dtype=numpy.float32)
         self.share["share_male"] = pandas.Series(
             0.5, self.zone_numbers, dtype=numpy.float32)
+        self.share["sh_age_18_99"] = 1 - self["sh_age_7_17"]
 
         # Convert household shares to population shares
         avg_hh_size = {
@@ -112,6 +113,7 @@ class ZoneData:
         self["sqrt_pop_density"] = numpy.sqrt(self["pop_density"])
         
         # Two-way intrazonal distances from building distances
+    
         self["dist_walk"] = data["intra_dist_walk"] * 2
         self["dist_bike"] = data["intra_dist_bike"] * 2
         self["time_car"] = 2 * 60 * data["intra_dist_car"] / 20

--- a/Scripts/parameters/demand/hb_edu_student.json
+++ b/Scripts/parameters/demand/hb_edu_student.json
@@ -135,31 +135,31 @@
         "car_drv": {
             "attraction": {},
             "impedance": {
-                "time": -0.061,
-                "cost": -0.03056
+                "time": -0.05376,
+                "cost": -0.03512
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3157
+                "cost": -0.2283
             },
             "attraction_size": {
                 "students_upper_secondary": 1,
-                "students_higher_education": 1.472851
+                "students_higher_education": 1.517403
             }
         },
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.06745,
-                "cost": -0.03056
+                "time": -0.07548,
+                "cost": -0.03512
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3157
+                "cost": -0.2283
             },
             "attraction_size": {
                 "students_upper_secondary": 1,
-                "students_higher_education": 1.472851
+                "students_higher_education": 1.517403
             }
         },
         "transit": {
@@ -167,92 +167,98 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.01547,
-                "cost": -0.03056
+                "time": -0.01618,
+                "cost": -0.03512
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3157
+                "cost": -0.2283
             },
             "attraction_size": {
                 "students_upper_secondary": 1,
-                "students_higher_education": 1.472851
+                "students_higher_education": 1.517403
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000165
+                "density_pop_wrk": -0.000159
             },
             "impedance": {
-                "dist": -0.319
+                "dist": -0.3197
             },
             "log": {
                 "attraction_size": 1.0
             },
             "attraction_size": {
                 "students_upper_secondary": 1,
-                "students_higher_education": 1.472851
+                "students_higher_education": 1.517403
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.6611
+                "dist": -0.665
             },
             "log": {
                 "attraction_size": 1.0
             },
             "attraction_size": {
                 "students_upper_secondary": 1,
-                "students_higher_education": 1.472851
+                "students_higher_education": 1.517403
             }
         }
     },
     "mode_choice": {
         "car_drv": {
-            "constant": -7.067,
+            "constant": -6.702,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6683
+                "logsum": 0.7565
             },
             "individual_dummy": {
-                "sh_cars1_hh1": 5.712,
-                "sh_cars2_hh2": 5.712,
-                "sh_cars1_hh2": 4.64
+                "sh_cars1_hh1*sh_age_7_17": -1e99,
+                "sh_cars2_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh1*sh_age_18_99": 6.222,
+                "sh_cars2_hh2*sh_age_18_99": 6.222,
+                "sh_cars1_hh2*sh_age_18_99": 4.47
+                
             }
         },
         "car_pax": {
-            "constant": -4.43,
+            "constant": -3.801,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6683
+                "logsum": 0.7565
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 1.236,
-                "sh_cars2_hh2": 1.236
+                "sh_cars1_hh2*sh_age_7_17": 0.703,
+                "sh_cars2_hh2*sh_age_7_17": 0.703,
+                "sh_cars1_hh2*sh_age_18_99": 0.703,
+                "sh_cars2_hh2*sh_age_18_99": 0.703
             }
         },
         "transit": {
-            "constant": -1.36,
+            "constant": -1.499,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6683
+                "logsum": 0.7565
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -1.069,
+            "constant": -1.054,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6683
+                "logsum": 0.7565
             },
             "individual_dummy": {}
         },
@@ -262,34 +268,39 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6683
+                "logsum": 0.7565
             },
             "individual_dummy": {}
         },
         "scaling": {
             "car_drv": {
-                "constant": 0.6683,
+                "constant": 0.7565,
                 "individual_dummy": {
-                    "sh_cars1_hh1": 0.6683,
-                    "sh_cars2_hh2": 0.6683,
-                    "sh_cars1_hh2": 0.6683
+                    "sh_cars1_hh1*sh_age_7_17": 0.7565,
+                    "sh_cars2_hh2*sh_age_7_17": 0.7565,
+                    "sh_cars1_hh2*sh_age_7_17": 0.7565,
+                    "sh_cars1_hh1*sh_age_18_99": 0.7565,
+                    "sh_cars2_hh2*sh_age_18_99": 0.7565,
+                    "sh_cars1_hh2*sh_age_18_99": 0.7565
                 }
             },
             "car_pax": {
-                "constant": 0.6683,
+                "constant": 0.7565,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.6683,
-                    "sh_cars2_hh2": 0.6683
+                    "sh_cars1_hh2*sh_age_7_17": 0.7565,
+                    "sh_cars2_hh2*sh_age_7_17": 0.7565,
+                    "sh_cars1_hh2*sh_age_18_99": 0.7565,
+                    "sh_cars2_hh2*sh_age_18_99": 0.7565
                 }
             },
             "transit": {
-                "constant": 0.6683
+                "constant": 0.7565
             },
             "bike": {
-                "constant": 0.6683
+                "constant": 0.7565
             },
             "walk": {
-                "constant": 0.6683
+                "constant": 0.7565
             }
         },
         "calibration": {

--- a/Scripts/parameters/demand/hb_edu_student_u18.json
+++ b/Scripts/parameters/demand/hb_edu_student_u18.json
@@ -1,5 +1,5 @@
 {
-    "name": "hb_edu_student",
+    "name": "hb_edu_student_u18",
     "orig": "home",
     "dest": "students_higher_education",
     "generation_area": "domestic",
@@ -10,20 +10,14 @@
         "0": {
             "constant": 6.097587,
             "individual_dummy": {
-                "sh_age_18_29": 0.0,
-                "sh_age_30_49": 0.0,
-                "sh_age_50_64": 0.0,
-                "sh_age_65_99": 0.0
+                "sh_age_7_17": 0.0
             },
             "generation": {}
         },
         "1": {
             "constant": 0.0,
             "individual_dummy": {
-                "sh_age_18_29": 3.275774,
-                "sh_age_30_49": 1.414134,
-                "sh_age_50_64": 0.0,
-                "sh_age_65_99": 0.0
+                "sh_age_7_17": 2.518241
             },
             "generation": {
                 "hb_edu_student": 0.146461
@@ -36,20 +30,6 @@
         "transit": 1.0585
     },
     "impedance_share": {
-        "car_drv": {
-            "aht": [
-                0.5653,
-                0.0253
-            ],
-            "pt": [
-                0.3986,
-                0.5374
-            ],
-            "iht": [
-                0.036,
-                0.4373
-            ]
-        },
         "car_pax": {
             "aht": [
                 0.5653,
@@ -108,10 +88,6 @@
         "car_pax": 2.238
     },
     "distance_boundaries": {
-        "car_drv": [
-            0,
-            300
-        ],
         "car_pax": [
             0,
             300
@@ -130,21 +106,6 @@
         ]
     },
     "destination_choice": {
-        "car_drv": {
-            "attraction": {},
-            "impedance": {
-                "time": -0.05376,
-                "cost": -0.03512
-            },
-            "log": {
-                "attraction_size": 1,
-                "cost": -0.2283
-            },
-            "attraction_size": {
-                "students_upper_secondary": 1,
-                "students_higher_education": 1.517403
-            }
-        },
         "car_pax": {
             "attraction": {},
             "impedance": {
@@ -207,21 +168,6 @@
         }
     },
     "mode_choice": {
-        "car_drv": {
-            "constant": -6.702,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 0.7565
-            },
-            "individual_dummy": {
-                "sh_cars1_hh1": 6.222,
-                "sh_cars2_hh2": 6.222,
-                "sh_cars1_hh2": 4.47
-                
-            }
-        },
         "car_pax": {
             "constant": -3.801,
             "generation": {},
@@ -266,14 +212,6 @@
             "individual_dummy": {}
         },
         "scaling": {
-            "car_drv": {
-                "constant": 0.7565,
-                "individual_dummy": {
-                    "sh_cars1_hh1": 0.7565,
-                    "sh_cars2_hh2": 0.7565,
-                    "sh_cars1_hh2": 0.7565
-                }
-            },
             "car_pax": {
                 "constant": 0.7565,
                 "individual_dummy": {
@@ -292,9 +230,6 @@
             }
         },
         "calibration": {
-            "car_drv": {
-                "constant": 0.0
-            },
             "car_pax": {
                 "constant": 0.0
             },

--- a/Scripts/parameters/demand/hb_escort.json
+++ b/Scripts/parameters/demand/hb_escort.json
@@ -120,33 +120,33 @@
         "car_drv": {
             "attraction": {},
             "impedance": {
-                "time": -0.0195,
-                "cost": -0.3002
+                "time": -0.02015,
+                "cost": -0.294
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.5093
+                "cost": -0.5094
             },
             "attraction_size": {
                 "students_comprehensive*within_municipality": 1,
-				"students_comprehensive*outside_municipality": 0.061115,
-                "population": 0.279431
+				"students_comprehensive*outside_municipality": 0.062039,
+                "population": 0.279711
             }
         },
         "car_pax": {
             "attraction": { },
             "impedance": {
-                "time": -0.007797,
-                "cost": -0.3002
+                "time": -0.008951,
+                "cost": -0.294
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.5093
+                "cost": -0.5094
             },
             "attraction_size": {
                 "students_comprehensive*within_municipality": 1,
-				"students_comprehensive*outside_municipality": 0.061115,
-                "population": 0.279431
+				"students_comprehensive*outside_municipality": 0.062039,
+                "population": 0.279711
             }
         },
         "transit": {
@@ -154,95 +154,100 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.00897,
-                "cost": -0.3002
+                "time": -0.008943,
+                "cost": -0.294
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.5093
+                "cost": -0.5094
             },
             "attraction_size": {
                 "students_comprehensive*within_municipality": 1,
-				"students_comprehensive*outside_municipality": 0.061115,
-                "population": 0.279431
+				"students_comprehensive*outside_municipality": 0.062039,
+                "population": 0.279711
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": 0.000001
+                "density_pop_wrk": 0.000008
             },
             "impedance": {
-                "dist": -0.5364
+                "dist": -0.5342
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "students_comprehensive*within_municipality": 1,
-				"students_comprehensive*outside_municipality": 0.061115,
-                "population": 0.279431
+				"students_comprehensive*outside_municipality": 0.062039,
+                "population": 0.279711
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.7777
+                "dist": -0.7805
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "students_comprehensive*within_municipality": 1,
-				"students_comprehensive*outside_municipality": 0.061115,
-                "population": 0.279431
+				"students_comprehensive*outside_municipality": 0.062039,
+                "population": 0.279711
             }
         }
     },
     "mode_choice": {
         "car_drv": {
-            "constant": -5.707,
+            "constant": -5.376,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.4254
+                "logsum": 0.4905
             },
             "individual_dummy": {
-                "sh_cars1_hh1": 8.085,
-                "sh_cars2_hh2": 8.085,
-                "sh_cars1_hh2": 6.598
+                "sh_cars1_hh1*sh_age_7_17": -1e99,
+                "sh_cars2_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh1*sh_age_18_99": 7.506,
+                "sh_cars2_hh2*sh_age_18_99": 7.506,
+                "sh_cars1_hh2*sh_age_18_99": 5.894
             }
         },
         "car_pax": {
-            "constant": -10.18,
+            "constant": -9.309,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.4254
+                "logsum": 0.4905
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 4.165,
-                "sh_cars2_hh2": 4.165
+                "sh_cars1_hh2*sh_age_7_17": 3.477,
+                "sh_cars2_hh2*sh_age_7_17": 3.477,
+                "sh_cars1_hh2*sh_age_18_99": 3.477,
+                "sh_cars2_hh2*sh_age_18_99": 3.477
             }
         },
         "transit": {
-            "constant": -4.944,
+            "constant": -4.406,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.4254
+                "logsum": 0.4905
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -4.587,
+            "constant": -4.074,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.4254
+                "logsum": 0.4905
             },
             "individual_dummy": {}
         },
@@ -252,34 +257,39 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.4254
+                "logsum": 0.4905
             },
             "individual_dummy": {}
         },
         "scaling": {
             "car_drv": {
-                "constant": 0.4254,
+                "constant": 0.4905,
                 "individual_dummy": {
-                    "sh_cars1_hh1": 0.4254,
-                    "sh_cars2_hh2": 0.4254,
-                    "sh_cars1_hh2": 0.4254
+                    "sh_cars1_hh1*sh_age_7_17": 0.4905,
+                    "sh_cars2_hh2*sh_age_7_17": 0.4905,
+                    "sh_cars1_hh2*sh_age_7_17": 0.4905,
+                    "sh_cars1_hh1*sh_age_18_99": 0.4905,
+                    "sh_cars2_hh2*sh_age_18_99": 0.4905,
+                    "sh_cars1_hh2*sh_age_18_99": 0.4905
                 }
             },
             "car_pax": {
-                "constant": 0.4254,
+                "constant": 0.4905,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.4254,
-                    "sh_cars2_hh2": 0.4254
+                    "sh_cars1_hh2*sh_age_7_17": 0.4905,
+                    "sh_cars2_hh2*sh_age_7_17": 0.4905,
+                    "sh_cars1_hh2*sh_age_18_99": 0.4905,
+                    "sh_cars2_hh2*sh_age_18_99": 0.4905
                 }
             },
             "transit": {
-                "constant": 0.4254
+                "constant": 0.4905
             },
             "bike": {
-                "constant": 0.4254
+                "constant": 0.4905
             },
             "walk": {
-                "constant": 0.4254
+                "constant": 0.4905
             }
         },
         "calibration": {

--- a/Scripts/parameters/demand/hb_escort.json
+++ b/Scripts/parameters/demand/hb_escort.json
@@ -8,14 +8,12 @@
     "gen_model": "rate",
     "generation": {
         "no_car": {
-            "age_7_17": 0,
             "age_18_29": 0.0064,
             "age_30_49": 0.0379,
             "age_50_64": 0.0044,
             "age_65_99": 0.0061
         },
         "has_car": {
-            "age_7_17": 0.0047,
             "age_18_29": 0.0203,
             "age_30_49": 0.0663,
             "age_50_64": 0.0302,
@@ -208,12 +206,9 @@
                 "logsum": 0.4905
             },
             "individual_dummy": {
-                "sh_cars1_hh1*sh_age_7_17": -1e99,
-                "sh_cars2_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh1*sh_age_18_99": 7.506,
-                "sh_cars2_hh2*sh_age_18_99": 7.506,
-                "sh_cars1_hh2*sh_age_18_99": 5.894
+                "sh_cars1_hh1": 7.506,
+                "sh_cars2_hh2": 7.506,
+                "sh_cars1_hh2": 5.894
             }
         },
         "car_pax": {
@@ -225,10 +220,8 @@
                 "logsum": 0.4905
             },
             "individual_dummy": {
-                "sh_cars1_hh2*sh_age_7_17": 3.477,
-                "sh_cars2_hh2*sh_age_7_17": 3.477,
-                "sh_cars1_hh2*sh_age_18_99": 3.477,
-                "sh_cars2_hh2*sh_age_18_99": 3.477
+                "sh_cars1_hh2": 3.477,
+                "sh_cars2_hh2": 3.477
             }
         },
         "transit": {
@@ -265,21 +258,16 @@
             "car_drv": {
                 "constant": 0.4905,
                 "individual_dummy": {
-                    "sh_cars1_hh1*sh_age_7_17": 0.4905,
-                    "sh_cars2_hh2*sh_age_7_17": 0.4905,
-                    "sh_cars1_hh2*sh_age_7_17": 0.4905,
-                    "sh_cars1_hh1*sh_age_18_99": 0.4905,
-                    "sh_cars2_hh2*sh_age_18_99": 0.4905,
-                    "sh_cars1_hh2*sh_age_18_99": 0.4905
+                    "sh_cars1_hh1": 0.4905,
+                    "sh_cars2_hh2": 0.4905,
+                    "sh_cars1_hh2": 0.4905
                 }
             },
             "car_pax": {
                 "constant": 0.4905,
                 "individual_dummy": {
-                    "sh_cars1_hh2*sh_age_7_17": 0.4905,
-                    "sh_cars2_hh2*sh_age_7_17": 0.4905,
-                    "sh_cars1_hh2*sh_age_18_99": 0.4905,
-                    "sh_cars2_hh2*sh_age_18_99": 0.4905
+                    "sh_cars1_hh2": 0.4905,
+                    "sh_cars2_hh2": 0.4905
                 }
             },
             "transit": {

--- a/Scripts/parameters/demand/hb_escort_u18.json
+++ b/Scripts/parameters/demand/hb_escort_u18.json
@@ -1,67 +1,55 @@
 {
-    "name": "wb_business",
-    "orig": "source",
-    "dest": "other",
-    "source": [
-        "hb_work"
-    ],
+    "name": "hb_escort_u18",
+    "orig": "home",
+    "dest": "escort",
     "generation_area": "domestic",
     "attraction_area": "domestic",
     "struct": "mode>dest",
     "gen_model": "rate",
     "generation": {
-        "hb_work": 0.0674
+        "no_car": {
+            "age_7_17": 0
+        },
+        "has_car": {
+            "age_7_17": 0.0047
+        }
     },
     "sec_dest_rate": {
-        "car_drv": 1.1013,
-        "car_pax": 1.0309,
-        "transit": 1.0009
+        "car_drv": 1.0161,
+        "car_pax": 1.0076,
+        "transit": 1.0000
     },
     "impedance_share": {
-        "car_drv": {
-            "aht": [
-                0.2841,
-                0.0415
-            ],
-            "pt": [
-                0.6965,
-                0.7603
-            ],
-            "iht": [
-                0.0194,
-                0.1982
-            ]
-        },
         "car_pax": {
             "aht": [
-                0.2841,
-                0.0415
+                0.2837,
+                0.2128
             ],
             "pt": [
-                0.6965,
-                0.7603
+                0.4419,
+                0.5142
             ],
             "iht": [
-                0.0194,
-                0.1982
+                0.2743,
+                0.273
             ]
         },
         "transit": {
             "aht": [
-                0.2841,
-                0.0415
+                0.2837,
+                0.2128
             ],
             "pt": [
-                0.6843,
-                0.7429
+                0.2564,
+                0.2733
             ],
             "iht": [
-                0.0194,
-                0.1982
+                0.2743,
+                0.273
             ],
             "it": [
-                0.0122,
-                0.0174
+                0.1855,
+                0.2409
             ]
         },
         "bike": {
@@ -77,22 +65,21 @@
             ]
         }
     },
-    "activity_time": 0.0,
+    "activity_time": 0.4,
     "parking_cost_share": 0.0,
-    "car_cost_sharing": 0.0,
-    "occupancy": {},
+    "car_cost_sharing": 1.0,
+    "occupancy": {
+        "car_drv": 1.81,
+        "car_pax": 2.89
+    },
     "distance_boundaries": {
-        "car_drv": [
-            0,
-            300
-        ],
         "car_pax": [
             0,
-            300
+            100
         ],
         "transit": [
             0,
-            300
+            100
         ],
         "bike": [
             0,
@@ -104,28 +91,20 @@
         ]
     },
     "destination_choice": {
-        "car_drv": {
-            "attraction": {},
-            "impedance": {
-                "time": -0.05263
-            },
-            "log": {
-                "attraction_size": 1
-            },
-            "attraction_size": {
-                "workplaces": 1
-            }
-        },
         "car_pax": {
-            "attraction": {},
+            "attraction": { },
             "impedance": {
-                "time": -0.04486
+                "time": -0.008951,
+                "cost": -0.294
             },
             "log": {
-                "attraction_size": 1
+                "attraction_size": 1,
+                "cost": -0.5094
             },
             "attraction_size": {
-                "workplaces": 1
+                "students_comprehensive*within_municipality": 1,
+				"students_comprehensive*outside_municipality": 0.062039,
+                "population": 0.279711
             }
         },
         "transit": {
@@ -133,86 +112,83 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.01965
+                "time": -0.008943,
+                "cost": -0.294
             },
             "log": {
-                "attraction_size": 1
+                "attraction_size": 1,
+                "cost": -0.5094
             },
             "attraction_size": {
-                "workplaces": 1
+                "students_comprehensive*within_municipality": 1,
+				"students_comprehensive*outside_municipality": 0.062039,
+                "population": 0.279711
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000149
+                "density_pop_wrk": 0.000008
             },
             "impedance": {
-                "dist": -0.4929
+                "dist": -0.5342
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "workplaces": 1
+                "students_comprehensive*within_municipality": 1,
+				"students_comprehensive*outside_municipality": 0.062039,
+                "population": 0.279711
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.9206
+                "dist": -0.7805
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "population": 1
+                "students_comprehensive*within_municipality": 1,
+				"students_comprehensive*outside_municipality": 0.062039,
+                "population": 0.279711
             }
         }
     },
     "mode_choice": {
-        "car_drv": {
-            "constant": -2.502,
+        "car_pax": {
+            "constant": -9.309,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1
+                "logsum": 0.4905
             },
             "individual_dummy": {
-                "wb_business_parent_car_drv_share": 2.697
+                "sh_cars1_hh2": 3.477,
+                "sh_cars2_hh2": 3.477
             }
         },
-        "car_pax": {
-            "constant": -2.672,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 1
-            },
-            "individual_dummy": {}
-        },
         "transit": {
-            "constant": -2.41,
+            "constant": -4.406,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1
+                "logsum": 0.4905
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -2.215,
+            "constant": -4.074,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1
+                "logsum": 0.4905
             },
-            "individual_dummy": {
-                "wb_business_parent_bike_share": 2.725
-            }
+            "individual_dummy": {}
         },
         "walk": {
             "constant": 0,
@@ -220,37 +196,29 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1
+                "logsum": 0.4905
             },
             "individual_dummy": {}
         },
         "scaling": {
-            "car_drv": {
-                "constant": 1,
-                "individual_dummy": {
-                    "wb_business_parent_car_drv_share": 1
-                }
-            },
             "car_pax": {
-                "constant": 1
+                "constant": 0.4905,
+                "individual_dummy": {
+                    "sh_cars1_hh2": 0.4905,
+                    "sh_cars2_hh2": 0.4905
+                }
             },
             "transit": {
-                "constant": 1
+                "constant": 0.4905
             },
             "bike": {
-                "constant": 1,
-                "individual_dummy": {
-                    "wb_business_parent_bike_share": 1
-                }
+                "constant": 0.4905
             },
             "walk": {
-                "constant": 1
+                "constant": 0.4905
             }
         },
         "calibration": {
-            "car_drv": {
-                "constant": 0.0
-            },
             "car_pax": {
                 "constant": 0.0
             },
@@ -268,30 +236,30 @@
     "demand_share": {
         "bike": {
             "aht": [
-                0.2841,
-                0.0415
+                0.0595,
+                0.01
             ],
             "pt": [
-                0.6965,
-                0.7603
+                0.5898,
+                0.8011
             ],
             "iht": [
-                0.0194,
-                0.1982
+                0.3508,
+                0.1889
             ]
         },
         "walk": {
             "aht": [
-                0.2841,
-                0.0415
+                0.0595,
+                0.01
             ],
             "pt": [
-                0.6965,
-                0.7603
+                0.5898,
+                0.8011
             ],
             "iht": [
-                0.0194,
-                0.1982
+                0.3508,
+                0.1889
             ]
         }
     }

--- a/Scripts/parameters/demand/hb_grocery.json
+++ b/Scripts/parameters/demand/hb_grocery.json
@@ -120,12 +120,12 @@
         "car_drv": {
             "attraction": {},
             "impedance": {
-                "time": -0.08215,
-                "cost": -0.2341
+                "time": -0.08229,
+                "cost": -0.2317
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3421
+                "cost": -0.3384
             },
             "attraction_size": {
                 "wrk_shop": 1
@@ -134,12 +134,12 @@
         "car_pax": {
             "attraction": { },
             "impedance": {
-                "time": -0.07711,
-                "cost": -0.2341
+                "time": -0.07864,
+                "cost": -0.2317
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3421
+                "cost": -0.3384
             },
             "attraction_size": {
                 "wrk_shop": 1
@@ -150,11 +150,11 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.02786
+                "time": -0.02791
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3421
+                "cost": -0.3384
             },
             "attraction_size": {
                 "wrk_shop": 1
@@ -162,10 +162,10 @@
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000139
+                "density_pop_wrk": -0.000138
             },
             "impedance": {
-                "dist": -0.4081
+                "dist": -0.4097
             },
             "log": {
                 "attraction_size": 1
@@ -177,7 +177,7 @@
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.9586
+                "dist": -0.9594
             },
             "log": {
                 "attraction_size": 1
@@ -189,55 +189,60 @@
     },
     "mode_choice": {
         "car_drv": {
-            "constant": -6.837,
+            "constant": -6.593,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6183
+                "logsum": 0.6443
             },
             "individual_dummy": {
-                "sh_cars1_hh1": 6.327,
-                "sh_cars2_hh2": 6.327,
-                "sh_cars1_hh2": 5.572
+                "sh_cars1_hh1*sh_age_7_17": -1e99,
+                "sh_cars2_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh1*sh_age_18_99": 6.45,
+                "sh_cars2_hh2*sh_age_18_99": 6.45,
+                "sh_cars1_hh2*sh_age_18_99": 5.473
             }
         },
         "car_pax": {
-            "constant": -6.385,
+            "constant": -6.148,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6183
+                "logsum": 0.6443
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 3.237,
-                "sh_cars2_hh2": 3.237
+                "sh_cars1_hh2*sh_age_7_17": 2.937,
+                "sh_cars2_hh2*sh_age_7_17": 2.937,
+                "sh_cars1_hh2*sh_age_18_99": 2.937,
+                "sh_cars2_hh2*sh_age_18_99": 2.937
             }
         },
         "transit": {
-            "constant": -4.818,
+            "constant": -4.645,
             "generation": {
-                "HSL": 1.286,
-                "Tampere": 1.38,
-                "Turku": 1.395
+                "HSL": 1.186,
+                "Tampere": 1.317,
+                "Turku": 1.36
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6183
+                "logsum": 0.6443
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -3.452,
+            "constant": -3.364,
             "generation": {
-                "Oulu": 1.095
+                "Oulu": 1.024
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6183
+                "logsum": 0.6443
             },
             "individual_dummy": {}
         },
@@ -247,42 +252,47 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6183
+                "logsum": 0.6443
             },
             "individual_dummy": {}
         },
         "scaling": {
             "car_drv": {
-                "constant": 0.6183,
+                "constant": 0.6443,
                 "individual_dummy": {
-                    "sh_cars1_hh1": 0.6183,
-                    "sh_cars2_hh2": 0.6183,
-                    "sh_cars1_hh2": 0.6183
+                    "sh_cars1_hh1*sh_age_7_17": 0.6443,
+                    "sh_cars2_hh2*sh_age_7_17": 0.6443,
+                    "sh_cars1_hh2*sh_age_7_17": 0.6443,
+                    "sh_cars1_hh1*sh_age_18_99": 0.6443,
+                    "sh_cars2_hh2*sh_age_18_99": 0.6443,
+                    "sh_cars1_hh2*sh_age_18_99": 0.6443
                 }
             },
             "car_pax": {
-                "constant": 0.6183,
+                "constant": 0.6443,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.6183,
-                    "sh_cars2_hh2": 0.6183
+                    "sh_cars1_hh2*sh_age_7_17": 0.6443,
+                    "sh_cars2_hh2*sh_age_7_17": 0.6443,
+                    "sh_cars1_hh2*sh_age_18_99": 0.6443,
+                    "sh_cars2_hh2*sh_age_18_99": 0.6443
                 }
             },
             "transit": {
-                "constant": 0.6183,
+                "constant": 0.6443,
                 "generation": {
-                    "HSL": 0.6183,
-                    "Tampere": 0.6183,
-                    "Turku": 0.6183
+                    "HSL": 0.6443,
+                    "Tampere": 0.6443,
+                    "Turku": 0.6443
                 }
             },
             "bike": {
-                "constant": 0.6183,
+                "constant": 0.6443,
                 "generation": {
-                    "Oulu": 0.6183
+                    "Oulu": 0.6443
                 }
             },
             "walk": {
-                "constant": 0.6183
+                "constant": 0.6443
             }
         },
         "calibration": {

--- a/Scripts/parameters/demand/hb_grocery_u18.json
+++ b/Scripts/parameters/demand/hb_grocery_u18.json
@@ -1,5 +1,5 @@
 {
-    "name": "hb_grocery",
+    "name": "hb_grocery_u18",
     "orig": "home",
     "dest": "wrk_shop",
     "generation_area": "domestic",
@@ -8,16 +8,10 @@
     "gen_model": "rate",
     "generation": {
         "no_car": {
-            "age_18_29": 0.1513,
-            "age_30_49": 0.1335,
-            "age_50_64": 0.1878,
-            "age_65_99": 0.1979
+            "age_7_17": 0.0988
         },
         "has_car": {
-            "age_18_29": 0.1146,
-            "age_30_49": 0.1287,
-            "age_50_64": 0.1356,
-            "age_65_99": 0.2138
+            "age_7_17": 0.0681
         }
     },
     "sec_dest_rate": {
@@ -26,20 +20,6 @@
         "transit": 1.0205
     },
     "impedance_share": {
-        "car_drv": {
-            "aht": [
-                0.0373,
-                0.0131
-            ],
-            "pt": [
-                0.7054,
-                0.7448
-            ],
-            "iht": [
-                0.2573,
-                0.2421
-            ]
-        },
         "car_pax": {
             "aht": [
                 0.0373,
@@ -93,10 +73,6 @@
         "car_pax": 2.395
     },
     "distance_boundaries": {
-        "car_drv": [
-            0,
-            100
-        ],
         "car_pax": [
             0,
             100
@@ -115,20 +91,6 @@
         ]
     },
     "destination_choice": {
-        "car_drv": {
-            "attraction": {},
-            "impedance": {
-                "time": -0.08229,
-                "cost": -0.2317
-            },
-            "log": {
-                "attraction_size": 1,
-                "cost": -0.3384
-            },
-            "attraction_size": {
-                "wrk_shop": 1
-            }
-        },
         "car_pax": {
             "attraction": { },
             "impedance": {
@@ -186,20 +148,6 @@
         }
     },
     "mode_choice": {
-        "car_drv": {
-            "constant": -6.593,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 0.6443
-            },
-            "individual_dummy": {
-                "sh_cars1_hh1": 6.45,
-                "sh_cars2_hh2": 6.45,
-                "sh_cars1_hh2": 5.473
-            }
-        },
         "car_pax": {
             "constant": -6.148,
             "generation": {},
@@ -250,14 +198,6 @@
             "individual_dummy": {}
         },
         "scaling": {
-            "car_drv": {
-                "constant": 0.6443,
-                "individual_dummy": {
-                    "sh_cars1_hh1": 0.6443,
-                    "sh_cars2_hh2": 0.6443,
-                    "sh_cars1_hh2": 0.6443
-                }
-            },
             "car_pax": {
                 "constant": 0.6443,
                 "individual_dummy": {
@@ -284,9 +224,6 @@
             }
         },
         "calibration": {
-            "car_drv": {
-                "constant": 0.0
-            },
             "car_pax": {
                 "constant": 0.0
             },

--- a/Scripts/parameters/demand/hb_leisure.json
+++ b/Scripts/parameters/demand/hb_leisure.json
@@ -120,31 +120,31 @@
         "car_drv": {
             "attraction": {},
             "impedance": {
-                "time": -0.03062,
-                "cost": 0.01255
+                "time": -0.03021,
+                "cost": 0.01235
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.8715
+                "cost": -0.8683
             },
             "attraction_size": {
                 "wrk_hospitality": 1,
-                "wrk_recreation": 1.415949
+                "wrk_recreation": 1.414251
             }
         },
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.02392,
-                "cost": 0.01255
+                "time": -0.02424,
+                "cost": 0.01235
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.8715
+                "cost": -0.8683
             },
             "attraction_size": {
                 "wrk_hospitality": 1,
-                "wrk_recreation": 1.415949
+                "wrk_recreation": 1.414251
             }
         },
         "transit": {
@@ -152,98 +152,103 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.01476,
-                "cost": 0.01255
+                "time": -0.01506,
+                "cost": 0.01235
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.8715
+                "cost": -0.8683
             },
             "attraction_size": {
                 "wrk_hospitality": 1,
-                "wrk_recreation": 1.415949
+                "wrk_recreation": 1.414251
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000073
+                "density_pop_wrk": -0.000071
             },
             "impedance": {
-                "dist": -0.2677
+                "dist": -0.2714
             },
             "log": {
                 "attraction_size": 1.0
             },
             "attraction_size": {
                 "wrk_hospitality": 1,
-                "wrk_recreation": 1.415949
+                "wrk_recreation": 1.414251
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.7627
+                "dist": -0.7644
             },
             "log": {
                 "attraction_size": 1.0
             },
             "attraction_size": {
                 "wrk_hospitality": 1,
-                "wrk_recreation": 1.415949
+                "wrk_recreation": 1.414251
             }
         }
     },
     "mode_choice": {
         "car_drv": {
-            "constant": -5.677,
+            "constant": -5.353,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6565
+                "logsum": 0.7101
             },
             "individual_dummy": {
-                "sh_cars1_hh1": 4.309,
-                "sh_cars2_hh2": 4.309,
-                "sh_cars1_hh2": 4.034
+                "sh_cars1_hh1*sh_age_7_17": -1e99,
+                "sh_cars2_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh1*sh_age_18_99": 4.571,
+                "sh_cars2_hh2*sh_age_18_99": 4.571,
+                "sh_cars1_hh2*sh_age_18_99": 4.023
             }
         },
         "car_pax": {
-            "constant": -5.068,
+            "constant": -4.803,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6565
+                "logsum": 0.7101
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 2.075,
-                "sh_cars2_hh2": 2.075
+                "sh_cars1_hh2*sh_age_7_17": 1.551,
+                "sh_cars2_hh2*sh_age_7_17": 1.551,
+                "sh_cars1_hh2*sh_age_18_99": 1.551,
+                "sh_cars2_hh2*sh_age_18_99": 1.551
             }
         },
         "transit": {
-            "constant": -3.139,
+            "constant": -2.966,
             "generation": {
-                "HSL": 1.746,
-                "Tampere": 0.8375,
-                "Turku": 0.6798
+                "HSL": 1.56,
+                "Tampere": 0.6309,
+                "Turku": 0.6728
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6565
+                "logsum": 0.7101
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -2.7,
+            "constant": -2.593,
             "generation": {
-                "Oulu": 1.574
+                "Oulu": 1.33
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6565
+                "logsum": 0.7101
             },
             "individual_dummy": {}
         },
@@ -253,42 +258,47 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6565
+                "logsum": 0.7101
             },
             "individual_dummy": {}
         },
         "scaling": {
             "car_drv": {
-                "constant": 0.6565,
+                "constant": 0.7101,
                 "individual_dummy": {
-                    "sh_cars1_hh1": 0.6565,
-                    "sh_cars2_hh2": 0.6565,
-                    "sh_cars1_hh2": 0.6565
+                    "sh_cars1_hh1*sh_age_7_17": 0.7101,
+                    "sh_cars2_hh2*sh_age_7_17": 0.7101,
+                    "sh_cars1_hh2*sh_age_7_17": 0.7101,
+                    "sh_cars1_hh1*sh_age_18_99": 0.7101,
+                    "sh_cars2_hh2*sh_age_18_99": 0.7101,
+                    "sh_cars1_hh2*sh_age_18_99": 0.7101
                 }
             },
             "car_pax": {
-                "constant": 0.6565,
+                "constant": 0.7101,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.6565,
-                    "sh_cars2_hh2": 0.6565
+                    "sh_cars1_hh2*sh_age_7_17": 0.7101,
+                    "sh_cars2_hh2*sh_age_7_17": 0.7101,
+                    "sh_cars1_hh2*sh_age_18_99": 0.7101,
+                    "sh_cars2_hh2*sh_age_18_99": 0.7101
                 }
             },
             "transit": {
-                "constant": 0.6565,
+                "constant": 0.7101,
                 "generation": {
-                    "HSL": 0.6565,
-                    "Tampere": 0.6565,
-                    "Turku": 0.6565
+                    "HSL": 0.7101,
+                    "Tampere": 0.7101,
+                    "Turku": 0.7101
                 }
             },
             "bike": {
-                "constant": 0.6565,
+                "constant": 0.7101,
                 "generation": {
-                    "Oulu": 0.6565
+                    "Oulu": 0.7101
                 }
             },
             "walk": {
-                "constant": 0.6565
+                "constant": 0.7101
             }
         },
         "calibration": {

--- a/Scripts/parameters/demand/hb_leisure.json
+++ b/Scripts/parameters/demand/hb_leisure.json
@@ -8,14 +8,12 @@
     "gen_model": "rate",
     "generation": {
         "no_car": {
-            "age_7_17": 0.128,
             "age_18_29": 0.1267,
             "age_30_49": 0.1226,
             "age_50_64": 0.1036,
             "age_65_99": 0.0897
         },
         "has_car": {
-            "age_7_17": 0.1736,
             "age_18_29": 0.1132,
             "age_30_49": 0.1292,
             "age_50_64": 0.1026,
@@ -203,12 +201,9 @@
                 "logsum": 0.7101
             },
             "individual_dummy": {
-                "sh_cars1_hh1*sh_age_7_17": -1e99,
-                "sh_cars2_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh1*sh_age_18_99": 4.571,
-                "sh_cars2_hh2*sh_age_18_99": 4.571,
-                "sh_cars1_hh2*sh_age_18_99": 4.023
+                "sh_cars1_hh1": 4.571,
+                "sh_cars2_hh2": 4.571,
+                "sh_cars1_hh2": 4.023
             }
         },
         "car_pax": {
@@ -220,10 +215,8 @@
                 "logsum": 0.7101
             },
             "individual_dummy": {
-                "sh_cars1_hh2*sh_age_7_17": 1.551,
-                "sh_cars2_hh2*sh_age_7_17": 1.551,
-                "sh_cars1_hh2*sh_age_18_99": 1.551,
-                "sh_cars2_hh2*sh_age_18_99": 1.551
+                "sh_cars1_hh2": 1.551,
+                "sh_cars2_hh2": 1.551
             }
         },
         "transit": {
@@ -266,21 +259,16 @@
             "car_drv": {
                 "constant": 0.7101,
                 "individual_dummy": {
-                    "sh_cars1_hh1*sh_age_7_17": 0.7101,
-                    "sh_cars2_hh2*sh_age_7_17": 0.7101,
-                    "sh_cars1_hh2*sh_age_7_17": 0.7101,
-                    "sh_cars1_hh1*sh_age_18_99": 0.7101,
-                    "sh_cars2_hh2*sh_age_18_99": 0.7101,
-                    "sh_cars1_hh2*sh_age_18_99": 0.7101
+                    "sh_cars1_hh1": 0.7101,
+                    "sh_cars2_hh2": 0.7101,
+                    "sh_cars1_hh2": 0.7101
                 }
             },
             "car_pax": {
                 "constant": 0.7101,
                 "individual_dummy": {
-                    "sh_cars1_hh2*sh_age_7_17": 0.7101,
-                    "sh_cars2_hh2*sh_age_7_17": 0.7101,
-                    "sh_cars1_hh2*sh_age_18_99": 0.7101,
-                    "sh_cars2_hh2*sh_age_18_99": 0.7101
+                    "sh_cars1_hh2": 0.7101,
+                    "sh_cars2_hh2": 0.7101
                 }
             },
             "transit": {

--- a/Scripts/parameters/demand/hb_leisure_u18.json
+++ b/Scripts/parameters/demand/hb_leisure_u18.json
@@ -1,67 +1,55 @@
 {
-    "name": "wb_business",
-    "orig": "source",
-    "dest": "other",
-    "source": [
-        "hb_work"
-    ],
+    "name": "hb_leisure_u18",
+    "orig": "home",
+    "dest": "leisure",
     "generation_area": "domestic",
     "attraction_area": "domestic",
     "struct": "mode>dest",
     "gen_model": "rate",
     "generation": {
-        "hb_work": 0.0674
+        "no_car": {
+            "age_7_17": 0.128
+        },
+        "has_car": {
+            "age_7_17": 0.1736
+        }
     },
     "sec_dest_rate": {
-        "car_drv": 1.1013,
-        "car_pax": 1.0309,
-        "transit": 1.0009
+        "car_drv": 1.119,
+        "car_pax": 1.0441,
+        "transit": 1.0697
     },
     "impedance_share": {
-        "car_drv": {
-            "aht": [
-                0.2841,
-                0.0415
-            ],
-            "pt": [
-                0.6965,
-                0.7603
-            ],
-            "iht": [
-                0.0194,
-                0.1982
-            ]
-        },
         "car_pax": {
             "aht": [
-                0.2841,
-                0.0415
+                0.0595,
+                0.01
             ],
             "pt": [
-                0.6965,
-                0.7603
+                0.5898,
+                0.8011
             ],
             "iht": [
-                0.0194,
-                0.1982
+                0.3508,
+                0.1889
             ]
         },
         "transit": {
             "aht": [
-                0.2841,
-                0.0415
+                0.0595,
+                0.01
             ],
             "pt": [
-                0.6843,
-                0.7429
+                0.3173,
+                0.2154
             ],
             "iht": [
-                0.0194,
-                0.1982
+                0.3508,
+                0.1889
             ],
             "it": [
-                0.0122,
-                0.0174
+                0.2725,
+                0.5857
             ]
         },
         "bike": {
@@ -77,15 +65,14 @@
             ]
         }
     },
-    "activity_time": 0.0,
-    "parking_cost_share": 0.0,
-    "car_cost_sharing": 0.0,
-    "occupancy": {},
+    "activity_time": 2.1,
+    "parking_cost_share": 0.75,
+    "car_cost_sharing": 1.0,
+    "occupancy": {
+        "car_drv": 1.731,
+        "car_pax": 2.841
+    },
     "distance_boundaries": {
-        "car_drv": [
-            0,
-            300
-        ],
         "car_pax": [
             0,
             300
@@ -104,28 +91,19 @@
         ]
     },
     "destination_choice": {
-        "car_drv": {
-            "attraction": {},
-            "impedance": {
-                "time": -0.05263
-            },
-            "log": {
-                "attraction_size": 1
-            },
-            "attraction_size": {
-                "workplaces": 1
-            }
-        },
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.04486
+                "time": -0.02424,
+                "cost": 0.01235
             },
             "log": {
-                "attraction_size": 1
+                "attraction_size": 1,
+                "cost": -0.8683
             },
             "attraction_size": {
-                "workplaces": 1
+                "wrk_hospitality": 1,
+                "wrk_recreation": 1.414251
             }
         },
         "transit": {
@@ -133,86 +111,86 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.01965
+                "time": -0.01506,
+                "cost": 0.01235
             },
             "log": {
-                "attraction_size": 1
+                "attraction_size": 1,
+                "cost": -0.8683
             },
             "attraction_size": {
-                "workplaces": 1
+                "wrk_hospitality": 1,
+                "wrk_recreation": 1.414251
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000149
+                "density_pop_wrk": -0.000071
             },
             "impedance": {
-                "dist": -0.4929
+                "dist": -0.2714
             },
             "log": {
-                "attraction_size": 1
+                "attraction_size": 1.0
             },
             "attraction_size": {
-                "workplaces": 1
+                "wrk_hospitality": 1,
+                "wrk_recreation": 1.414251
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.9206
+                "dist": -0.7644
             },
             "log": {
-                "attraction_size": 1
+                "attraction_size": 1.0
             },
             "attraction_size": {
-                "population": 1
+                "wrk_hospitality": 1,
+                "wrk_recreation": 1.414251
             }
         }
     },
     "mode_choice": {
-        "car_drv": {
-            "constant": -2.502,
+        "car_pax": {
+            "constant": -4.803,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1
+                "logsum": 0.7101
             },
             "individual_dummy": {
-                "wb_business_parent_car_drv_share": 2.697
+                "sh_cars1_hh2": 1.551,
+                "sh_cars2_hh2": 1.551
             }
         },
-        "car_pax": {
-            "constant": -2.672,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 1
-            },
-            "individual_dummy": {}
-        },
         "transit": {
-            "constant": -2.41,
-            "generation": {},
+            "constant": -2.966,
+            "generation": {
+                "HSL": 1.56,
+                "Tampere": 0.6309,
+                "Turku": 0.6728
+            },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1
+                "logsum": 0.7101
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -2.215,
-            "generation": {},
+            "constant": -2.593,
+            "generation": {
+                "Oulu": 1.33
+            },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1
+                "logsum": 0.7101
             },
-            "individual_dummy": {
-                "wb_business_parent_bike_share": 2.725
-            }
+            "individual_dummy": {}
         },
         "walk": {
             "constant": 0,
@@ -220,37 +198,37 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 1
+                "logsum": 0.7101
             },
             "individual_dummy": {}
         },
         "scaling": {
-            "car_drv": {
-                "constant": 1,
+            "car_pax": {
+                "constant": 0.7101,
                 "individual_dummy": {
-                    "wb_business_parent_car_drv_share": 1
+                    "sh_cars1_hh2": 0.7101,
+                    "sh_cars2_hh2": 0.7101
                 }
             },
-            "car_pax": {
-                "constant": 1
-            },
             "transit": {
-                "constant": 1
+                "constant": 0.7101,
+                "generation": {
+                    "HSL": 0.7101,
+                    "Tampere": 0.7101,
+                    "Turku": 0.7101
+                }
             },
             "bike": {
-                "constant": 1,
-                "individual_dummy": {
-                    "wb_business_parent_bike_share": 1
+                "constant": 0.7101,
+                "generation": {
+                    "Oulu": 0.7101
                 }
             },
             "walk": {
-                "constant": 1
+                "constant": 0.7101
             }
         },
         "calibration": {
-            "car_drv": {
-                "constant": 0.0
-            },
             "car_pax": {
                 "constant": 0.0
             },
@@ -268,30 +246,30 @@
     "demand_share": {
         "bike": {
             "aht": [
-                0.2841,
-                0.0415
+                0.0595,
+                0.01
             ],
             "pt": [
-                0.6965,
-                0.7603
+                0.5898,
+                0.8011
             ],
             "iht": [
-                0.0194,
-                0.1982
+                0.3508,
+                0.1889
             ]
         },
         "walk": {
             "aht": [
-                0.2841,
-                0.0415
+                0.0595,
+                0.01
             ],
             "pt": [
-                0.6965,
-                0.7603
+                0.5898,
+                0.8011
             ],
             "iht": [
-                0.0194,
-                0.1982
+                0.3508,
+                0.1889
             ]
         }
     }

--- a/Scripts/parameters/demand/hb_other_shop.json
+++ b/Scripts/parameters/demand/hb_other_shop.json
@@ -8,14 +8,12 @@
     "gen_model": "rate",
     "generation": {
         "no_car": {
-            "age_7_17": 0.0533,
             "age_18_29": 0.0731,
             "age_30_49": 0.1245,
             "age_50_64": 0.1711,
             "age_65_99": 0.1788
         },
         "has_car": {
-            "age_7_17": 0.0695,
             "age_18_29": 0.0912,
             "age_30_49": 0.1233,
             "age_50_64": 0.1381,
@@ -203,12 +201,9 @@
                 "logsum": 0.6614
             },
             "individual_dummy": {
-                "sh_cars1_hh1*sh_age_7_17": -1e99,
-                "sh_cars2_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh1*sh_age_18_99": 6.153,
-                "sh_cars2_hh2*sh_age_18_99": 6.153,
-                "sh_cars1_hh2*sh_age_18_99": 5.151
+                "sh_cars1_hh1": 6.153,
+                "sh_cars2_hh2": 6.153,
+                "sh_cars1_hh2": 5.151
             }
         },
         "car_pax": {
@@ -220,10 +215,8 @@
                 "logsum": 0.6614
             },
             "individual_dummy": {
-                "sh_cars1_hh2*sh_age_7_17": 2.372,
-                "sh_cars2_hh2*sh_age_7_17": 2.372,
-                "sh_cars1_hh2*sh_age_18_99": 2.372,
-                "sh_cars2_hh2*sh_age_18_99": 2.372
+                "sh_cars1_hh2": 2.372,
+                "sh_cars2_hh2": 2.372
             }
         },
         "transit": {
@@ -266,21 +259,16 @@
             "car_drv": {
                 "constant": 0.6614,
                 "individual_dummy": {
-                    "sh_cars1_hh1*sh_age_7_17": 0.6614,
-                    "sh_cars2_hh2*sh_age_7_17": 0.6614,
-                    "sh_cars1_hh2*sh_age_7_17": 0.6614,
-                    "sh_cars1_hh1*sh_age_18_99": 0.6614,
-                    "sh_cars2_hh2*sh_age_18_99": 0.6614,
-                    "sh_cars1_hh2*sh_age_18_99": 0.6614
+                    "sh_cars1_hh1": 0.6614,
+                    "sh_cars2_hh2": 0.6614,
+                    "sh_cars1_hh2": 0.6614
                 }
             },
             "car_pax": {
                 "constant": 0.6614,
                 "individual_dummy": {
-                    "sh_cars1_hh2*sh_age_7_17": 0.6614,
-                    "sh_cars2_hh2*sh_age_7_17": 0.6614,
-                    "sh_cars1_hh2*sh_age_18_99": 0.6614,
-                    "sh_cars2_hh2*sh_age_18_99": 0.6614
+                    "sh_cars1_hh2": 0.6614,
+                    "sh_cars2_hh2": 0.6614
                 }
             },
             "transit": {

--- a/Scripts/parameters/demand/hb_other_shop.json
+++ b/Scripts/parameters/demand/hb_other_shop.json
@@ -120,31 +120,31 @@
         "car_drv": {
             "attraction": {},
             "impedance": {
-                "time": -0.05457,
-                "cost": -0.0469
+                "time": -0.05441,
+                "cost": -0.04521
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3429
+                "cost": -0.3424
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_healthcare": 0.143417
+                "wrk_healthcare": 0.142987
             }
         },
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.05067,
-                "cost": -0.0469
+                "time": -0.05131,
+                "cost": -0.04521
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3429
+                "cost": -0.3424
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_healthcare": 0.143417
+                "wrk_healthcare": 0.142987
             }
         },
         "transit": {
@@ -152,16 +152,16 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.02081,
-                "cost": -0.0469
+                "time": -0.021,
+                "cost": -0.04521
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3429
+                "cost": -0.3424
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_healthcare": 0.143417
+                "wrk_healthcare": 0.142987
             }
         },
         "bike": {
@@ -169,81 +169,86 @@
                 "density_pop_wrk": -0.000048
             },
             "impedance": {
-                "dist": -0.2629
+                "dist": -0.2664
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_healthcare": 0.143417
+                "wrk_healthcare": 0.142987
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.661
+                "dist": -0.6596
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_healthcare": 0.143417
+                "wrk_healthcare": 0.142987
             }
         }
     },
     "mode_choice": {
         "car_drv": {
-            "constant": -5.851,
+            "constant": -5.585,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6147
+                "logsum": 0.6614
             },
             "individual_dummy": {
-                "sh_cars1_hh1": 6.094,
-                "sh_cars2_hh2": 6.094,
-                "sh_cars1_hh2": 5.413
+                "sh_cars1_hh1*sh_age_7_17": -1e99,
+                "sh_cars2_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh1*sh_age_18_99": 6.153,
+                "sh_cars2_hh2*sh_age_18_99": 6.153,
+                "sh_cars1_hh2*sh_age_18_99": 5.151
             }
         },
         "car_pax": {
-            "constant": -4.744,
+            "constant": -4.501,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6147
+                "logsum": 0.6614
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 2.801,
-                "sh_cars2_hh2": 2.801
+                "sh_cars1_hh2*sh_age_7_17": 2.372,
+                "sh_cars2_hh2*sh_age_7_17": 2.372,
+                "sh_cars1_hh2*sh_age_18_99": 2.372,
+                "sh_cars2_hh2*sh_age_18_99": 2.372
             }
         },
         "transit": {
-            "constant": -2.773,
+            "constant": -2.616,
             "generation": {
-                "HSL": 1.126,
-                "Tampere": 0.3843,
-                "Turku": 0.9728
+                "HSL": 0.9787,
+                "Tampere": 0.3015,
+                "Turku": 0.9024
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6147
+                "logsum": 0.6614
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -3.02,
+            "constant": -2.874,
             "generation": {
-                "Oulu": 1.425
+                "Oulu": 1.204
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6147
+                "logsum": 0.6614
             },
             "individual_dummy": {}
         },
@@ -253,42 +258,47 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6147
+                "logsum": 0.6614
             },
             "individual_dummy": {}
         },
         "scaling": {
             "car_drv": {
-                "constant": 0.6147,
+                "constant": 0.6614,
                 "individual_dummy": {
-                    "sh_cars1_hh1": 0.6147,
-                    "sh_cars2_hh2": 0.6147,
-                    "sh_cars1_hh2": 0.6147
+                    "sh_cars1_hh1*sh_age_7_17": 0.6614,
+                    "sh_cars2_hh2*sh_age_7_17": 0.6614,
+                    "sh_cars1_hh2*sh_age_7_17": 0.6614,
+                    "sh_cars1_hh1*sh_age_18_99": 0.6614,
+                    "sh_cars2_hh2*sh_age_18_99": 0.6614,
+                    "sh_cars1_hh2*sh_age_18_99": 0.6614
                 }
             },
             "car_pax": {
-                "constant": 0.6147,
+                "constant": 0.6614,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.6147,
-                    "sh_cars2_hh2": 0.6147
+                    "sh_cars1_hh2*sh_age_7_17": 0.6614,
+                    "sh_cars2_hh2*sh_age_7_17": 0.6614,
+                    "sh_cars1_hh2*sh_age_18_99": 0.6614,
+                    "sh_cars2_hh2*sh_age_18_99": 0.6614
                 }
             },
             "transit": {
-                "constant": 0.6147,
+                "constant": 0.6614,
                 "generation": {
-                    "HSL": 0.6147,
-                    "Tampere": 0.6147,
-                    "Turku": 0.6147
+                    "HSL": 0.6614,
+                    "Tampere": 0.6614,
+                    "Turku": 0.6614
                 }
             },
             "bike": {
-                "constant": 0.6147,
+                "constant": 0.6614,
                 "generation": {
-                    "Oulu": 0.6147
+                    "Oulu": 0.6614
                 }
             },
             "walk": {
-                "constant": 0.6147
+                "constant": 0.6614
             }
         },
         "calibration": {

--- a/Scripts/parameters/demand/hb_other_shop_u18.json
+++ b/Scripts/parameters/demand/hb_other_shop_u18.json
@@ -1,5 +1,5 @@
 {
-    "name": "hb_grocery",
+    "name": "hb_other_shop_u18",
     "orig": "home",
     "dest": "wrk_shop",
     "generation_area": "domestic",
@@ -8,68 +8,48 @@
     "gen_model": "rate",
     "generation": {
         "no_car": {
-            "age_18_29": 0.1513,
-            "age_30_49": 0.1335,
-            "age_50_64": 0.1878,
-            "age_65_99": 0.1979
+            "age_7_17": 0.0533
         },
         "has_car": {
-            "age_18_29": 0.1146,
-            "age_30_49": 0.1287,
-            "age_50_64": 0.1356,
-            "age_65_99": 0.2138
+            "age_7_17": 0.0695
         }
     },
     "sec_dest_rate": {
-        "car_drv": 1.0743,
-        "car_pax": 1.0741,
-        "transit": 1.0205
+        "car_drv": 1.0787,
+        "car_pax": 1.0846,
+        "transit": 1.0557
     },
     "impedance_share": {
-        "car_drv": {
-            "aht": [
-                0.0373,
-                0.0131
-            ],
-            "pt": [
-                0.7054,
-                0.7448
-            ],
-            "iht": [
-                0.2573,
-                0.2421
-            ]
-        },
         "car_pax": {
             "aht": [
-                0.0373,
-                0.0131
+                0.111,
+                0.038
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.6861,
+                0.7197
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.2028,
+                0.2423
             ]
         },
         "transit": {
             "aht": [
-                0.0373,
-                0.0131
+                0.111,
+                0.038
             ],
             "pt": [
-                0.5188,
-                0.4963
+                0.5842,
+                0.5292
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.2028,
+                0.2423
             ],
             "it": [
-                0.1866,
-                0.2485
+                0.1019,
+                0.1905
             ]
         },
         "bike": {
@@ -85,18 +65,14 @@
             ]
         }
     },
-    "activity_time": 0.7,
-    "parking_cost_share": 1.0,
+    "activity_time": 1.2,
+    "parking_cost_share": 0.15,
     "car_cost_sharing": 1.0,
     "occupancy": {
-        "car_drv": 1.53,
-        "car_pax": 2.395
+        "car_drv": 1.524,
+        "car_pax": 2.502
     },
     "distance_boundaries": {
-        "car_drv": [
-            0,
-            100
-        ],
         "car_pax": [
             0,
             100
@@ -115,32 +91,19 @@
         ]
     },
     "destination_choice": {
-        "car_drv": {
+        "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.08229,
-                "cost": -0.2317
+                "time": -0.05131,
+                "cost": -0.04521
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3384
+                "cost": -0.3424
             },
             "attraction_size": {
-                "wrk_shop": 1
-            }
-        },
-        "car_pax": {
-            "attraction": { },
-            "impedance": {
-                "time": -0.07864,
-                "cost": -0.2317
-            },
-            "log": {
-                "attraction_size": 1,
-                "cost": -0.3384
-            },
-            "attraction_size": {
-                "wrk_shop": 1
+                "wrk_shop": 1,
+                "wrk_healthcare": 0.142987
             }
         },
         "transit": {
@@ -148,94 +111,84 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.02791
+                "time": -0.021,
+                "cost": -0.04521
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3384
+                "cost": -0.3424
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "wrk_shop": 1,
+                "wrk_healthcare": 0.142987
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000138
+                "density_pop_wrk": -0.000048
             },
             "impedance": {
-                "dist": -0.4097
+                "dist": -0.2664
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "wrk_shop": 1,
+                "wrk_healthcare": 0.142987
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.9594
+                "dist": -0.6596
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "wrk_shop": 1,
+                "wrk_healthcare": 0.142987
             }
         }
     },
     "mode_choice": {
-        "car_drv": {
-            "constant": -6.593,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 0.6443
-            },
-            "individual_dummy": {
-                "sh_cars1_hh1": 6.45,
-                "sh_cars2_hh2": 6.45,
-                "sh_cars1_hh2": 5.473
-            }
-        },
         "car_pax": {
-            "constant": -6.148,
+            "constant": -4.501,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.6614
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 2.937,
-                "sh_cars2_hh2": 2.937
+                "sh_cars1_hh2": 2.372,
+                "sh_cars2_hh2": 2.372
             }
         },
         "transit": {
-            "constant": -4.645,
+            "constant": -2.616,
             "generation": {
-                "HSL": 1.186,
-                "Tampere": 1.317,
-                "Turku": 1.36
+                "HSL": 0.9787,
+                "Tampere": 0.3015,
+                "Turku": 0.9024
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.6614
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -3.364,
+            "constant": -2.874,
             "generation": {
-                "Oulu": 1.024
+                "Oulu": 1.204
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.6614
             },
             "individual_dummy": {}
         },
@@ -245,48 +198,37 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.6614
             },
             "individual_dummy": {}
         },
         "scaling": {
-            "car_drv": {
-                "constant": 0.6443,
-                "individual_dummy": {
-                    "sh_cars1_hh1": 0.6443,
-                    "sh_cars2_hh2": 0.6443,
-                    "sh_cars1_hh2": 0.6443
-                }
-            },
             "car_pax": {
-                "constant": 0.6443,
+                "constant": 0.6614,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.6443,
-                    "sh_cars2_hh2": 0.6443
+                    "sh_cars1_hh2": 0.6614,
+                    "sh_cars2_hh2": 0.6614
                 }
             },
             "transit": {
-                "constant": 0.6443,
+                "constant": 0.6614,
                 "generation": {
-                    "HSL": 0.6443,
-                    "Tampere": 0.6443,
-                    "Turku": 0.6443
+                    "HSL": 0.6614,
+                    "Tampere": 0.6614,
+                    "Turku": 0.6614
                 }
             },
             "bike": {
-                "constant": 0.6443,
+                "constant": 0.6614,
                 "generation": {
-                    "Oulu": 0.6443
+                    "Oulu": 0.6614
                 }
             },
             "walk": {
-                "constant": 0.6443
+                "constant": 0.6614
             }
         },
         "calibration": {
-            "car_drv": {
-                "constant": 0.0
-            },
             "car_pax": {
                 "constant": 0.0
             },
@@ -304,30 +246,30 @@
     "demand_share": {
         "bike": {
             "aht": [
-                0.0373,
-                0.0131
+                0.111,
+                0.038
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.6861,
+                0.7197
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.2028,
+                0.2423
             ]
         },
         "walk": {
             "aht": [
-                0.0373,
-                0.0131
+                0.111,
+                0.038
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.6861,
+                0.7197
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.2028,
+                0.2423
             ]
         }
     }

--- a/Scripts/parameters/demand/hb_sport.json
+++ b/Scripts/parameters/demand/hb_sport.json
@@ -8,14 +8,12 @@
     "gen_model": "rate",
     "generation": {
         "no_car": {
-            "age_7_17": 0.0639,
             "age_18_29": 0.0688,
             "age_30_49": 0.0738,
             "age_50_64": 0.0658,
             "age_65_99": 0.0407
         },
         "has_car": {
-            "age_7_17": 0.1542,
             "age_18_29": 0.0729,
             "age_30_49": 0.096,
             "age_50_64": 0.0635,
@@ -203,12 +201,9 @@
                 "logsum": 0.5674
             },
             "individual_dummy": {
-                "sh_cars1_hh1*sh_age_7_17": -1e99,
-                "sh_cars2_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh1*sh_age_18_99": 6.061,
-                "sh_cars2_hh2*sh_age_18_99": 6.061,
-                "sh_cars1_hh2*sh_age_18_99": 5.235
+                "sh_cars1_hh1": 6.061,
+                "sh_cars2_hh2": 6.061,
+                "sh_cars1_hh2": 5.235
             }
         },
         "car_pax": {
@@ -220,10 +215,8 @@
                 "logsum": 0.5674
             },
             "individual_dummy": {
-                "sh_cars1_hh2*sh_age_7_17": 2.304,
-                "sh_cars2_hh2*sh_age_7_17": 2.304,
-                "sh_cars1_hh2*sh_age_18_99": 2.304,
-                "sh_cars2_hh2*sh_age_18_99": 2.304
+                "sh_cars1_hh2": 2.304,
+                "sh_cars2_hh2": 2.304
             }
         },
         "transit": {
@@ -266,21 +259,16 @@
             "car_drv": {
                 "constant": 0.5674,
                 "individual_dummy": {
-                    "sh_cars1_hh1*sh_age_7_17": 0.5674,
-                    "sh_cars2_hh2*sh_age_7_17": 0.5674,
-                    "sh_cars1_hh2*sh_age_7_17": 0.5674,
-                    "sh_cars1_hh1*sh_age_18_99": 0.5674,
-                    "sh_cars2_hh2*sh_age_18_99": 0.5674,
-                    "sh_cars1_hh2*sh_age_18_99": 0.5674
+                    "sh_cars1_hh1": 0.5674,
+                    "sh_cars2_hh2": 0.5674,
+                    "sh_cars1_hh2": 0.5674
                 }
             },
             "car_pax": {
                 "constant": 0.5674,
                 "individual_dummy": {
-                    "sh_cars1_hh2*sh_age_7_17": 0.5674,
-                    "sh_cars2_hh2*sh_age_7_17": 0.5674,
-                    "sh_cars1_hh2*sh_age_18_99": 0.5674,
-                    "sh_cars2_hh2*sh_age_18_99": 0.5674
+                    "sh_cars1_hh2": 0.5674,
+                    "sh_cars2_hh2": 0.5674
                 }
             },
             "transit": {

--- a/Scripts/parameters/demand/hb_sport.json
+++ b/Scripts/parameters/demand/hb_sport.json
@@ -120,31 +120,31 @@
         "car_drv": {
             "attraction": {},
             "impedance": {
-                "time": -0.02128,
-                "cost": -0.1331
+                "time": -0.02076,
+                "cost": -0.1332
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.6652
+                "cost": -0.6611
             },
             "attraction_size": {
                 "sport_facility_indoor": 1,
-                "sport_facility_outdoor": 0.115556
+                "sport_facility_outdoor": 0.114635
             }
         },
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.02344,
-                "cost": -0.1331
+                "time": -0.02408,
+                "cost": -0.1332
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.6652
+                "cost": -0.6611
             },
             "attraction_size": {
                 "sport_facility_indoor": 1,
-                "sport_facility_outdoor": 0.115556
+                "sport_facility_outdoor": 0.114635
             }
         },
         "transit": {
@@ -152,98 +152,103 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.02328,
-                "cost": -0.1331
+                "time": -0.02335,
+                "cost": -0.1332
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.6652
+                "cost": -0.6611
             },
             "attraction_size": {
                 "sport_facility_indoor": 1,
-                "sport_facility_outdoor": 0.115556
+                "sport_facility_outdoor": 0.114635
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000033
+                "density_pop_wrk": -0.000032
             },
             "impedance": {
-                "dist": -0.2809
+                "dist": -0.2828
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "sport_facility_indoor": 1,
-                "sport_facility_outdoor": 0.115556
+                "sport_facility_outdoor": 0.114635
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.5339
+                "dist": -0.5331
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "sport_facility_indoor": 1,
-                "sport_facility_outdoor": 0.115556
+                "sport_facility_outdoor": 0.114635
             }
         }
     },
     "mode_choice": {
         "car_drv": {
-            "constant": -8.091,
+            "constant": -7.118,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.4763
+                "logsum": 0.5674
             },
             "individual_dummy": {
-                "sh_cars1_hh1": 5.841,
-                "sh_cars2_hh2": 5.841,
-                "sh_cars1_hh2": 5.4
+                "sh_cars1_hh1*sh_age_7_17": -1e99,
+                "sh_cars2_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh1*sh_age_18_99": 6.061,
+                "sh_cars2_hh2*sh_age_18_99": 6.061,
+                "sh_cars1_hh2*sh_age_18_99": 5.235
             }
         },
         "car_pax": {
-            "constant": -6.942,
+            "constant": -6.103,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.4763
+                "logsum": 0.5674
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 3.237,
-                "sh_cars2_hh2": 3.237
+                "sh_cars1_hh2*sh_age_7_17": 2.304,
+                "sh_cars2_hh2*sh_age_7_17": 2.304,
+                "sh_cars1_hh2*sh_age_18_99": 2.304,
+                "sh_cars2_hh2*sh_age_18_99": 2.304
             }
         },
         "transit": {
-            "constant": -6.204,
+            "constant": -4.913,
             "generation": {
-                "HSL": 4.289,
-                "Tampere": 0.8063,
-                "Turku": 3.745
+                "HSL": 3.37,
+                "Tampere": 0.406,
+                "Turku": 3.162
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.4763
+                "logsum": 0.5674
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -3.029,
+            "constant": -2.678,
             "generation": {
-                "Oulu": 1.667
+                "Oulu": 1.334
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.4763
+                "logsum": 0.5674
             },
             "individual_dummy": {}
         },
@@ -253,42 +258,47 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.4763
+                "logsum": 0.5674
             },
             "individual_dummy": {}
         },
         "scaling": {
             "car_drv": {
-                "constant": 0.4763,
+                "constant": 0.5674,
                 "individual_dummy": {
-                    "sh_cars1_hh1": 0.4763,
-                    "sh_cars2_hh2": 0.4763,
-                    "sh_cars1_hh2": 0.4763
+                    "sh_cars1_hh1*sh_age_7_17": 0.5674,
+                    "sh_cars2_hh2*sh_age_7_17": 0.5674,
+                    "sh_cars1_hh2*sh_age_7_17": 0.5674,
+                    "sh_cars1_hh1*sh_age_18_99": 0.5674,
+                    "sh_cars2_hh2*sh_age_18_99": 0.5674,
+                    "sh_cars1_hh2*sh_age_18_99": 0.5674
                 }
             },
             "car_pax": {
-                "constant": 0.4763,
+                "constant": 0.5674,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.4763,
-                    "sh_cars2_hh2": 0.4763
+                    "sh_cars1_hh2*sh_age_7_17": 0.5674,
+                    "sh_cars2_hh2*sh_age_7_17": 0.5674,
+                    "sh_cars1_hh2*sh_age_18_99": 0.5674,
+                    "sh_cars2_hh2*sh_age_18_99": 0.5674
                 }
             },
             "transit": {
-                "constant": 0.4763,
+                "constant": 0.5674,
                 "generation": {
-                    "HSL": 0.4763,
-                    "Tampere": 0.4763,
-                    "Turku": 0.4763
+                    "HSL": 0.5674,
+                    "Tampere": 0.5674,
+                    "Turku": 0.5674
                 }
             },
             "bike": {
-                "constant": 0.4763,
+                "constant": 0.5674,
                 "generation": {
-                    "Oulu": 0.4763
+                    "Oulu": 0.5674
                 }
             },
             "walk": {
-                "constant": 0.4763
+                "constant": 0.5674
             }
         },
         "calibration": {

--- a/Scripts/parameters/demand/hb_sport_u18.json
+++ b/Scripts/parameters/demand/hb_sport_u18.json
@@ -1,75 +1,55 @@
 {
-    "name": "hb_grocery",
+    "name": "hb_sport_u18",
     "orig": "home",
-    "dest": "wrk_shop",
+    "dest": "sport",
     "generation_area": "domestic",
     "attraction_area": "domestic",
     "struct": "mode>dest",
     "gen_model": "rate",
     "generation": {
         "no_car": {
-            "age_18_29": 0.1513,
-            "age_30_49": 0.1335,
-            "age_50_64": 0.1878,
-            "age_65_99": 0.1979
+            "age_7_17": 0.0639
         },
         "has_car": {
-            "age_18_29": 0.1146,
-            "age_30_49": 0.1287,
-            "age_50_64": 0.1356,
-            "age_65_99": 0.2138
+            "age_7_17": 0.1542
         }
     },
     "sec_dest_rate": {
-        "car_drv": 1.0743,
-        "car_pax": 1.0741,
-        "transit": 1.0205
+        "car_drv": 1.0327,
+        "car_pax": 1.0316,
+        "transit": 1.0102
     },
     "impedance_share": {
-        "car_drv": {
-            "aht": [
-                0.0373,
-                0.0131
-            ],
-            "pt": [
-                0.7054,
-                0.7448
-            ],
-            "iht": [
-                0.2573,
-                0.2421
-            ]
-        },
         "car_pax": {
             "aht": [
-                0.0373,
-                0.0131
+                0.09,
+                0.0477
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.5917,
+                0.7839
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.3182,
+                0.1684
             ]
         },
         "transit": {
             "aht": [
-                0.0373,
-                0.0131
+                0.09,
+                0.0477
             ],
             "pt": [
-                0.5188,
-                0.4963
+                0.287,
+                0.2344
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.3182,
+                0.1684
             ],
             "it": [
-                0.1866,
-                0.2485
+                0.3047,
+                0.5495
             ]
         },
         "bike": {
@@ -85,25 +65,21 @@
             ]
         }
     },
-    "activity_time": 0.7,
-    "parking_cost_share": 1.0,
+    "activity_time": 1.6,
+    "parking_cost_share": 0.0,
     "car_cost_sharing": 1.0,
     "occupancy": {
-        "car_drv": 1.53,
-        "car_pax": 2.395
+        "car_drv": 1.651,
+        "car_pax": 2.791
     },
     "distance_boundaries": {
-        "car_drv": [
-            0,
-            100
-        ],
         "car_pax": [
             0,
-            100
+            300
         ],
         "transit": [
             0,
-            100
+            300
         ],
         "bike": [
             0,
@@ -115,32 +91,19 @@
         ]
     },
     "destination_choice": {
-        "car_drv": {
+        "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.08229,
-                "cost": -0.2317
+                "time": -0.02408,
+                "cost": -0.1332
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3384
+                "cost": -0.6611
             },
             "attraction_size": {
-                "wrk_shop": 1
-            }
-        },
-        "car_pax": {
-            "attraction": { },
-            "impedance": {
-                "time": -0.07864,
-                "cost": -0.2317
-            },
-            "log": {
-                "attraction_size": 1,
-                "cost": -0.3384
-            },
-            "attraction_size": {
-                "wrk_shop": 1
+                "sport_facility_indoor": 1,
+                "sport_facility_outdoor": 0.114635
             }
         },
         "transit": {
@@ -148,94 +111,84 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.02791
+                "time": -0.02335,
+                "cost": -0.1332
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3384
+                "cost": -0.6611
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "sport_facility_indoor": 1,
+                "sport_facility_outdoor": 0.114635
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000138
+                "density_pop_wrk": -0.000032
             },
             "impedance": {
-                "dist": -0.4097
+                "dist": -0.2828
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "sport_facility_indoor": 1,
+                "sport_facility_outdoor": 0.114635
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.9594
+                "dist": -0.5331
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "sport_facility_indoor": 1,
+                "sport_facility_outdoor": 0.114635
             }
         }
     },
     "mode_choice": {
-        "car_drv": {
-            "constant": -6.593,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 0.6443
-            },
-            "individual_dummy": {
-                "sh_cars1_hh1": 6.45,
-                "sh_cars2_hh2": 6.45,
-                "sh_cars1_hh2": 5.473
-            }
-        },
         "car_pax": {
-            "constant": -6.148,
+            "constant": -6.103,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.5674
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 2.937,
-                "sh_cars2_hh2": 2.937
+                "sh_cars1_hh2": 2.304,
+                "sh_cars2_hh2": 2.304
             }
         },
         "transit": {
-            "constant": -4.645,
+            "constant": -4.913,
             "generation": {
-                "HSL": 1.186,
-                "Tampere": 1.317,
-                "Turku": 1.36
+                "HSL": 3.37,
+                "Tampere": 0.406,
+                "Turku": 3.162
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.5674
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -3.364,
+            "constant": -2.678,
             "generation": {
-                "Oulu": 1.024
+                "Oulu": 1.334
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.5674
             },
             "individual_dummy": {}
         },
@@ -245,48 +198,37 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.5674
             },
             "individual_dummy": {}
         },
         "scaling": {
-            "car_drv": {
-                "constant": 0.6443,
-                "individual_dummy": {
-                    "sh_cars1_hh1": 0.6443,
-                    "sh_cars2_hh2": 0.6443,
-                    "sh_cars1_hh2": 0.6443
-                }
-            },
             "car_pax": {
-                "constant": 0.6443,
+                "constant": 0.5674,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.6443,
-                    "sh_cars2_hh2": 0.6443
+                    "sh_cars1_hh2": 0.5674,
+                    "sh_cars2_hh2": 0.5674
                 }
             },
             "transit": {
-                "constant": 0.6443,
+                "constant": 0.5674,
                 "generation": {
-                    "HSL": 0.6443,
-                    "Tampere": 0.6443,
-                    "Turku": 0.6443
+                    "HSL": 0.5674,
+                    "Tampere": 0.5674,
+                    "Turku": 0.5674
                 }
             },
             "bike": {
-                "constant": 0.6443,
+                "constant": 0.5674,
                 "generation": {
-                    "Oulu": 0.6443
+                    "Oulu": 0.5674
                 }
             },
             "walk": {
-                "constant": 0.6443
+                "constant": 0.5674
             }
         },
         "calibration": {
-            "car_drv": {
-                "constant": 0.0
-            },
             "car_pax": {
                 "constant": 0.0
             },
@@ -304,30 +246,30 @@
     "demand_share": {
         "bike": {
             "aht": [
-                0.0373,
-                0.0131
+                0.09,
+                0.0477
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.5917,
+                0.7839
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.3182,
+                0.1684
             ]
         },
         "walk": {
             "aht": [
-                0.0373,
-                0.0131
+                0.09,
+                0.0477
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.5917,
+                0.7839
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.3182,
+                0.1684
             ]
         }
     }

--- a/Scripts/parameters/demand/hb_visit.json
+++ b/Scripts/parameters/demand/hb_visit.json
@@ -8,14 +8,12 @@
     "gen_model": "rate",
     "generation": {
         "no_car": {
-            "age_7_17": 0.0936,
             "age_18_29": 0.1146,
             "age_30_49": 0.0891,
             "age_50_64": 0.0713,
             "age_65_99": 0.0864
         },
         "has_car": {
-            "age_7_17": 0.1601,
             "age_18_29": 0.1419,
             "age_30_49": 0.1106,
             "age_50_64": 0.128,
@@ -223,12 +221,9 @@
                 "logsum": 0.1598
             },
             "individual_dummy": {
-                "sh_cars1_hh1*sh_age_7_17": -1e99,
-                "sh_cars2_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh1*sh_age_18_99": 21.39,
-                "sh_cars2_hh2*sh_age_18_99": 21.39,
-                "sh_cars1_hh2*sh_age_18_99": 17.24
+                "sh_cars1_hh1": 21.39,
+                "sh_cars2_hh2": 21.39,
+                "sh_cars1_hh2": 17.24
             }
         },
         "car_pax": {
@@ -240,10 +235,8 @@
                 "logsum": 0.1598
             },
             "individual_dummy": {
-                "sh_cars1_hh2*sh_age_7_17": 7.105,
-                "sh_cars2_hh2*sh_age_7_17": 7.105,
-                "sh_cars1_hh2*sh_age_18_99": 7.105,
-                "sh_cars2_hh2*sh_age_18_99": 7.105
+                "sh_cars1_hh2": 7.105,
+                "sh_cars2_hh2": 7.105
             }
         },
         "transit": {
@@ -286,21 +279,16 @@
             "car_drv": {
                 "constant": 0.1598,
                 "individual_dummy": {
-                    "sh_cars1_hh1*sh_age_7_17": 0.1598,
-                    "sh_cars2_hh2*sh_age_7_17": 0.1598,
-                    "sh_cars1_hh2*sh_age_7_17": 0.1598,
-                    "sh_cars1_hh1*sh_age_18_99": 0.1598,
-                    "sh_cars2_hh2*sh_age_18_99": 0.1598,
-                    "sh_cars1_hh2*sh_age_18_99": 0.1598
+                    "sh_cars1_hh1": 0.1598,
+                    "sh_cars2_hh2": 0.1598,
+                    "sh_cars1_hh2": 0.1598
                 }
             },
             "car_pax": {
                 "constant": 0.1598,
                 "individual_dummy": {
-                    "sh_cars1_hh2*sh_age_7_17": 0.1598,
-                    "sh_cars2_hh2*sh_age_7_17": 0.1598,
-                    "sh_cars1_hh2*sh_age_18_99": 0.1598,
-                    "sh_cars2_hh2*sh_age_18_99": 0.1598
+                    "sh_cars1_hh2": 0.1598,
+                    "sh_cars2_hh2": 0.1598
                 }
             },
             "transit": {

--- a/Scripts/parameters/demand/hb_visit.json
+++ b/Scripts/parameters/demand/hb_visit.json
@@ -120,39 +120,39 @@
         "car_drv": {
             "attraction": {},
             "impedance": {
-                "time": -0.02521,
-                "cost": -0.01373
+                "time": -0.02443,
+                "cost": -0.01635
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.6863
+                "cost": -0.6854
             },
             "attraction_size": {
                 "age_7_17": 1,
                 "age_18_29": 1,
                 "age_30_49": 1,
-                "age_50_64": 2.577449,
-                "age_65_99": 2.577449,
-                "area_leisure_buildings": 0.321744
+                "age_50_64": 2.767654,
+                "age_65_99": 2.767654,
+                "area_leisure_buildings": 0.33824
             }
         },
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.0245,
-                "cost": -0.01373
+                "time": -0.02443,
+                "cost": -0.01635
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.6863
+                "cost": -0.6854
             },
             "attraction_size": {
                 "age_7_17": 1,
                 "age_18_29": 1,
                 "age_30_49": 1,
-                "age_50_64": 2.577449,
-                "age_65_99": 2.577449,
-                "area_leisure_buildings": 0.321744
+                "age_50_64": 2.767654,
+                "age_65_99": 2.767654,
+                "area_leisure_buildings": 0.33824
             }
         },
         "transit": {
@@ -160,28 +160,28 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.01277,
-                "cost": -0.01373
+                "time": -0.01211,
+                "cost": -0.01635
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.6863
+                "cost": -0.6854
             },
             "attraction_size": {
                 "age_7_17": 1,
                 "age_18_29": 1,
                 "age_30_49": 1,
-                "age_50_64": 2.577449,
-                "age_65_99": 2.577449,
-                "area_leisure_buildings": 0.321744
+                "age_50_64": 2.767654,
+                "age_65_99": 2.767654,
+                "area_leisure_buildings": 0.33824
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000114
+                "density_pop_wrk": -0.000128
             },
             "impedance": {
-                "dist": -0.2914
+                "dist": -0.2923
             },
             "log": {
                 "attraction_size": 1
@@ -190,15 +190,15 @@
                 "age_7_17": 1,
                 "age_18_29": 1,
                 "age_30_49": 1,
-                "age_50_64": 2.577449,
-                "age_65_99": 2.577449,
-                "area_leisure_buildings": 0.321744
+                "age_50_64": 2.767654,
+                "age_65_99": 2.767654,
+                "area_leisure_buildings": 0.33824
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.6857
+                "dist": -0.6851
             },
             "log": {
                 "attraction_size": 1
@@ -207,56 +207,68 @@
                 "age_7_17": 1,
                 "age_18_29": 1,
                 "age_30_49": 1,
-                "age_50_64": 2.577449,
-                "age_65_99": 2.577449,
-                "area_leisure_buildings": 0.321744
+                "age_50_64": 2.767654,
+                "age_65_99": 2.767654,
+                "area_leisure_buildings": 0.33824
             }
         }
     },
     "mode_choice": {
         "car_drv": {
-            "constant": 1.634,
+            "constant": -11.06,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.2427
+                "logsum": 0.1598
             },
-            "individual_dummy": {}
+            "individual_dummy": {
+                "sh_cars1_hh1*sh_age_7_17": -1e99,
+                "sh_cars2_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh1*sh_age_18_99": 21.39,
+                "sh_cars2_hh2*sh_age_18_99": 21.39,
+                "sh_cars1_hh2*sh_age_18_99": 17.24
+            }
         },
         "car_pax": {
-            "constant": -3.198,
+            "constant": -8.059,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.2427
+                "logsum": 0.1598
             },
-            "individual_dummy": {}
+            "individual_dummy": {
+                "sh_cars1_hh2*sh_age_7_17": 7.105,
+                "sh_cars2_hh2*sh_age_7_17": 7.105,
+                "sh_cars1_hh2*sh_age_18_99": 7.105,
+                "sh_cars2_hh2*sh_age_18_99": 7.105
+            }
         },
         "transit": {
-            "constant": -11.53,
+            "constant": -17.4,
             "generation": {
-                "HSL": 11.39,
-                "Tampere": 6.194,
-                "Turku": 4.538
+                "HSL": 17.32,
+                "Tampere": 9.481,
+                "Turku": 7.274
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.2427
+                "logsum": 0.1598
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -4.631,
+            "constant": -6.455,
             "generation": {
-                "Oulu": 4.252
+                "Oulu": 6.017
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.2427
+                "logsum": 0.1598
             },
             "individual_dummy": {}
         },
@@ -266,33 +278,47 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.2427
+                "logsum": 0.1598
             },
             "individual_dummy": {}
         },
         "scaling": {
             "car_drv": {
-                "constant": 0.2427
+                "constant": 0.1598,
+                "individual_dummy": {
+                    "sh_cars1_hh1*sh_age_7_17": 0.1598,
+                    "sh_cars2_hh2*sh_age_7_17": 0.1598,
+                    "sh_cars1_hh2*sh_age_7_17": 0.1598,
+                    "sh_cars1_hh1*sh_age_18_99": 0.1598,
+                    "sh_cars2_hh2*sh_age_18_99": 0.1598,
+                    "sh_cars1_hh2*sh_age_18_99": 0.1598
+                }
             },
             "car_pax": {
-                "constant": 0.2427
+                "constant": 0.1598,
+                "individual_dummy": {
+                    "sh_cars1_hh2*sh_age_7_17": 0.1598,
+                    "sh_cars2_hh2*sh_age_7_17": 0.1598,
+                    "sh_cars1_hh2*sh_age_18_99": 0.1598,
+                    "sh_cars2_hh2*sh_age_18_99": 0.1598
+                }
             },
             "transit": {
-                "constant": 0.2427,
+                "constant": 0.1598,
                 "generation": {
-                    "HSL": 0.2427,
-                    "Tampere": 0.2427,
-                    "Turku": 0.2427
+                    "HSL": 0.1598,
+                    "Tampere": 0.1598,
+                    "Turku": 0.1598
                 }
             },
             "bike": {
-                "constant": 0.2427,
+                "constant": 0.1598,
                 "generation": {
-                    "Oulu": 0.2427
+                    "Oulu": 0.1598
                 }
             },
             "walk": {
-                "constant": 0.2427
+                "constant": 0.1598
             }
         },
         "calibration": {

--- a/Scripts/parameters/demand/hb_visit_u18.json
+++ b/Scripts/parameters/demand/hb_visit_u18.json
@@ -1,75 +1,55 @@
 {
-    "name": "hb_grocery",
+    "name": "hb_visit_u18",
     "orig": "home",
-    "dest": "wrk_shop",
+    "dest": "population",
     "generation_area": "domestic",
     "attraction_area": "domestic",
     "struct": "mode>dest",
     "gen_model": "rate",
     "generation": {
         "no_car": {
-            "age_18_29": 0.1513,
-            "age_30_49": 0.1335,
-            "age_50_64": 0.1878,
-            "age_65_99": 0.1979
+            "age_7_17": 0.0936
         },
         "has_car": {
-            "age_18_29": 0.1146,
-            "age_30_49": 0.1287,
-            "age_50_64": 0.1356,
-            "age_65_99": 0.2138
+            "age_7_17": 0.1601
         }
     },
     "sec_dest_rate": {
-        "car_drv": 1.0743,
-        "car_pax": 1.0741,
-        "transit": 1.0205
+        "car_drv": 1.1209,
+        "car_pax": 1.0806,
+        "transit": 1.0663
     },
     "impedance_share": {
-        "car_drv": {
-            "aht": [
-                0.0373,
-                0.0131
-            ],
-            "pt": [
-                0.7054,
-                0.7448
-            ],
-            "iht": [
-                0.2573,
-                0.2421
-            ]
-        },
         "car_pax": {
             "aht": [
-                0.0373,
-                0.0131
+                0.0609,
+                0.0093
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.6104,
+                0.7219
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.3287,
+                0.2688
             ]
         },
         "transit": {
             "aht": [
-                0.0373,
-                0.0131
+                0.0609,
+                0.0093
             ],
             "pt": [
-                0.5188,
-                0.4963
+                0.4049,
+                0.1826
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.3287,
+                0.2688
             ],
             "it": [
-                0.1866,
-                0.2485
+                0.2055,
+                0.5393
             ]
         },
         "bike": {
@@ -85,25 +65,21 @@
             ]
         }
     },
-    "activity_time": 0.7,
-    "parking_cost_share": 1.0,
-    "car_cost_sharing": 1.0,
+    "activity_time": 2.4,
+    "parking_cost_share": 0.75,
+    "car_cost_sharing": 0.25,
     "occupancy": {
-        "car_drv": 1.53,
-        "car_pax": 2.395
+        "car_drv": 1.739,
+        "car_pax": 2.936
     },
     "distance_boundaries": {
-        "car_drv": [
-            0,
-            100
-        ],
         "car_pax": [
             0,
-            100
+            300
         ],
         "transit": [
             0,
-            100
+            300
         ],
         "bike": [
             0,
@@ -115,32 +91,23 @@
         ]
     },
     "destination_choice": {
-        "car_drv": {
+        "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.08229,
-                "cost": -0.2317
+                "time": -0.02443,
+                "cost": -0.01635
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3384
+                "cost": -0.6854
             },
             "attraction_size": {
-                "wrk_shop": 1
-            }
-        },
-        "car_pax": {
-            "attraction": { },
-            "impedance": {
-                "time": -0.07864,
-                "cost": -0.2317
-            },
-            "log": {
-                "attraction_size": 1,
-                "cost": -0.3384
-            },
-            "attraction_size": {
-                "wrk_shop": 1
+                "age_7_17": 1,
+                "age_18_29": 1,
+                "age_30_49": 1,
+                "age_50_64": 2.767654,
+                "age_65_99": 2.767654,
+                "area_leisure_buildings": 0.33824
             }
         },
         "transit": {
@@ -148,94 +115,96 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.02791
+                "time": -0.01211,
+                "cost": -0.01635
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3384
+                "cost": -0.6854
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "age_7_17": 1,
+                "age_18_29": 1,
+                "age_30_49": 1,
+                "age_50_64": 2.767654,
+                "age_65_99": 2.767654,
+                "area_leisure_buildings": 0.33824
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000138
+                "density_pop_wrk": -0.000128
             },
             "impedance": {
-                "dist": -0.4097
+                "dist": -0.2923
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "age_7_17": 1,
+                "age_18_29": 1,
+                "age_30_49": 1,
+                "age_50_64": 2.767654,
+                "age_65_99": 2.767654,
+                "area_leisure_buildings": 0.33824
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.9594
+                "dist": -0.6851
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "age_7_17": 1,
+                "age_18_29": 1,
+                "age_30_49": 1,
+                "age_50_64": 2.767654,
+                "age_65_99": 2.767654,
+                "area_leisure_buildings": 0.33824
             }
         }
     },
     "mode_choice": {
-        "car_drv": {
-            "constant": -6.593,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 0.6443
-            },
-            "individual_dummy": {
-                "sh_cars1_hh1": 6.45,
-                "sh_cars2_hh2": 6.45,
-                "sh_cars1_hh2": 5.473
-            }
-        },
         "car_pax": {
-            "constant": -6.148,
+            "constant": -8.059,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.1598
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 2.937,
-                "sh_cars2_hh2": 2.937
+                "sh_cars1_hh2": 7.105,
+                "sh_cars2_hh2": 7.105
             }
         },
         "transit": {
-            "constant": -4.645,
+            "constant": -17.4,
             "generation": {
-                "HSL": 1.186,
-                "Tampere": 1.317,
-                "Turku": 1.36
+                "HSL": 17.32,
+                "Tampere": 9.481,
+                "Turku": 7.274
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.1598
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -3.364,
+            "constant": -6.455,
             "generation": {
-                "Oulu": 1.024
+                "Oulu": 6.017
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.1598
             },
             "individual_dummy": {}
         },
@@ -245,48 +214,37 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.1598
             },
             "individual_dummy": {}
         },
         "scaling": {
-            "car_drv": {
-                "constant": 0.6443,
-                "individual_dummy": {
-                    "sh_cars1_hh1": 0.6443,
-                    "sh_cars2_hh2": 0.6443,
-                    "sh_cars1_hh2": 0.6443
-                }
-            },
             "car_pax": {
-                "constant": 0.6443,
+                "constant": 0.1598,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.6443,
-                    "sh_cars2_hh2": 0.6443
+                    "sh_cars1_hh2": 0.1598,
+                    "sh_cars2_hh2": 0.1598
                 }
             },
             "transit": {
-                "constant": 0.6443,
+                "constant": 0.1598,
                 "generation": {
-                    "HSL": 0.6443,
-                    "Tampere": 0.6443,
-                    "Turku": 0.6443
+                    "HSL": 0.1598,
+                    "Tampere": 0.1598,
+                    "Turku": 0.1598
                 }
             },
             "bike": {
-                "constant": 0.6443,
+                "constant": 0.1598,
                 "generation": {
-                    "Oulu": 0.6443
+                    "Oulu": 0.1598
                 }
             },
             "walk": {
-                "constant": 0.6443
+                "constant": 0.1598
             }
         },
         "calibration": {
-            "car_drv": {
-                "constant": 0.0
-            },
             "car_pax": {
                 "constant": 0.0
             },
@@ -304,30 +262,30 @@
     "demand_share": {
         "bike": {
             "aht": [
-                0.0373,
-                0.0131
+                0.0609,
+                0.0093
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.6104,
+                0.7219
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.3287,
+                0.2688
             ]
         },
         "walk": {
             "aht": [
-                0.0373,
-                0.0131
+                0.0609,
+                0.0093
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.6104,
+                0.7219
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.3287,
+                0.2688
             ]
         }
     }

--- a/Scripts/parameters/demand/hb_work.json
+++ b/Scripts/parameters/demand/hb_work.json
@@ -120,12 +120,12 @@
         "car_drv": {
             "attraction": {},
             "impedance": {
-                "time": -0.02876,
-                "cost": -0.05425
+                "time": -0.02861,
+                "cost": -0.05483
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.1863
+                "cost": -0.183
             },
             "attraction_size": {
                 "workplaces": 1
@@ -134,12 +134,12 @@
         "car_pax": {
             "attraction": { },
             "impedance": {
-                "time": -0.05862,
-                "cost": -0.05425
+                "time": -0.0587,
+                "cost": -0.05483
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.1863
+                "cost": -0.183
             },
             "attraction_size": {
                 "workplaces": 1
@@ -151,12 +151,12 @@
                 "sh_office": 1.531
             },
             "impedance": {
-                "time": -0.01051,
-                "cost": -0.05425
+                "time": -0.01049,
+                "cost": -0.05483
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.1863
+                "cost": -0.183
             },
             "attraction_size": {
                 "workplaces": 1
@@ -167,7 +167,7 @@
                 "density_pop_wrk": -0.000022
             },
             "impedance": {
-                "dist": -0.1419
+                "dist": -0.142
             },
             "log": {
                 "attraction_size": 1
@@ -179,7 +179,7 @@
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.4952
+                "dist": -0.4948
             },
             "log": {
                 "attraction_size": 1
@@ -191,55 +191,60 @@
     },
     "mode_choice": {
         "car_drv": {
-            "constant": -3.905,
+            "constant": -3.895,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.858
+                "logsum": 0.8643
             },
             "individual_dummy": {
-                "sh_cars1_hh1": 5.118,
-                "sh_cars2_hh2": 5.118,
-                "sh_cars1_hh2": 3.402
+                "sh_cars1_hh1*sh_age_7_17": -1e99,
+                "sh_cars2_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh2*sh_age_7_17": -1e99,
+                "sh_cars1_hh1*sh_age_18_99": 5.108,
+                "sh_cars2_hh2*sh_age_18_99": 5.108,
+                "sh_cars1_hh2*sh_age_18_99": 3.378
             }
         },
         "car_pax": {
-            "constant": -4.501,
+            "constant": -4.458,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.858
+                "logsum": 0.8643
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 0.9661,
-                "sh_cars2_hh2": 0.9661
+                "sh_cars1_hh2*sh_age_7_17": 0.9409,
+                "sh_cars2_hh2*sh_age_7_17": 0.9409,
+                "sh_cars1_hh2*sh_age_18_99": 0.9409,
+                "sh_cars2_hh2*sh_age_18_99": 0.9409
             }
         },
         "transit": {
-            "constant": -2.576,
+            "constant": -2.582,
             "generation": {
-                "HSL": 1.308,
-                "Tampere": 0.5775,
-                "Turku": 0.4555
+                "HSL": 1.298,
+                "Tampere": 0.5799,
+                "Turku": 0.4511
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.858
+                "logsum": 0.8643
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -1.291,
+            "constant": -1.288,
             "generation": {
-                "Oulu": 0.895
+                "Oulu": 0.8642
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.858
+                "logsum": 0.8643
             },
             "individual_dummy": {}
         },
@@ -249,42 +254,47 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.858
+                "logsum": 0.8643
             },
             "individual_dummy": {}
         },
         "scaling": {
             "car_drv": {
-                "constant": 0.858,
+                "constant": 0.8643,
                 "individual_dummy": {
-                    "sh_cars1_hh1": 0.858,
-                    "sh_cars2_hh2": 0.858,
-                    "sh_cars1_hh2": 0.858
+                    "sh_cars1_hh1*sh_age_7_17": 0.8643,
+                    "sh_cars2_hh2*sh_age_7_17": 0.8643,
+                    "sh_cars1_hh2*sh_age_7_17": 0.8643,
+                    "sh_cars1_hh1*sh_age_18_99": 0.8643,
+                    "sh_cars2_hh2*sh_age_18_99": 0.8643,
+                    "sh_cars1_hh2*sh_age_18_99": 0.8643
                 }
             },
             "car_pax": {
-                "constant": 0.858,
+                "constant": 0.8643,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.858,
-                    "sh_cars2_hh2": 0.858
+                    "sh_cars1_hh2*sh_age_7_17": 0.8643,
+                    "sh_cars2_hh2*sh_age_7_17": 0.8643,
+                    "sh_cars1_hh2*sh_age_18_99": 0.8643,
+                    "sh_cars2_hh2*sh_age_18_99": 0.8643
                 }
             },
             "transit": {
-                "constant": 0.858,
+                "constant": 0.8643,
                 "generation": {
-                    "HSL": 0.858,
-                    "Tampere": 0.858,
-                    "Turku": 0.858
+                    "HSL": 0.8643,
+                    "Tampere": 0.8643,
+                    "Turku": 0.8643
                 }
             },
             "bike": {
-                "constant": 0.858,
+                "constant": 0.8643,
                 "generation": {
-                    "Oulu": 0.858
+                    "Oulu": 0.8643
                 }
             },
             "walk": {
-                "constant": 0.858
+                "constant": 0.8643
             }
         },
         "calibration": {

--- a/Scripts/parameters/demand/hb_work.json
+++ b/Scripts/parameters/demand/hb_work.json
@@ -8,14 +8,12 @@
     "gen_model": "rate",
     "generation": {
         "no_car": {
-            "age_7_17": 0.0056,
             "age_18_29": 0.2545,
             "age_30_49": 0.345,
             "age_50_64": 0.2157,
             "age_65_99": 0.0062
         },
         "has_car": {
-            "age_7_17": 0.0069,
             "age_18_29": 0.2942,
             "age_30_49": 0.4014,
             "age_50_64": 0.3191,
@@ -199,12 +197,9 @@
                 "logsum": 0.8643
             },
             "individual_dummy": {
-                "sh_cars1_hh1*sh_age_7_17": -1e99,
-                "sh_cars2_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh2*sh_age_7_17": -1e99,
-                "sh_cars1_hh1*sh_age_18_99": 5.108,
-                "sh_cars2_hh2*sh_age_18_99": 5.108,
-                "sh_cars1_hh2*sh_age_18_99": 3.378
+                "sh_cars1_hh1": 5.108,
+                "sh_cars2_hh2": 5.108,
+                "sh_cars1_hh2": 3.378
             }
         },
         "car_pax": {
@@ -216,10 +211,8 @@
                 "logsum": 0.8643
             },
             "individual_dummy": {
-                "sh_cars1_hh2*sh_age_7_17": 0.9409,
-                "sh_cars2_hh2*sh_age_7_17": 0.9409,
-                "sh_cars1_hh2*sh_age_18_99": 0.9409,
-                "sh_cars2_hh2*sh_age_18_99": 0.9409
+                "sh_cars1_hh2": 0.9409,
+                "sh_cars2_hh2": 0.9409
             }
         },
         "transit": {
@@ -262,21 +255,16 @@
             "car_drv": {
                 "constant": 0.8643,
                 "individual_dummy": {
-                    "sh_cars1_hh1*sh_age_7_17": 0.8643,
-                    "sh_cars2_hh2*sh_age_7_17": 0.8643,
-                    "sh_cars1_hh2*sh_age_7_17": 0.8643,
-                    "sh_cars1_hh1*sh_age_18_99": 0.8643,
-                    "sh_cars2_hh2*sh_age_18_99": 0.8643,
-                    "sh_cars1_hh2*sh_age_18_99": 0.8643
+                    "sh_cars1_hh1": 0.8643,
+                    "sh_cars2_hh2": 0.8643,
+                    "sh_cars1_hh2": 0.8643
                 }
             },
             "car_pax": {
                 "constant": 0.8643,
                 "individual_dummy": {
-                    "sh_cars1_hh2*sh_age_7_17": 0.8643,
-                    "sh_cars2_hh2*sh_age_7_17": 0.8643,
-                    "sh_cars1_hh2*sh_age_18_99": 0.8643,
-                    "sh_cars2_hh2*sh_age_18_99": 0.8643
+                    "sh_cars1_hh2": 0.8643,
+                    "sh_cars2_hh2": 0.8643
                 }
             },
             "transit": {

--- a/Scripts/parameters/demand/hb_work_u18.json
+++ b/Scripts/parameters/demand/hb_work_u18.json
@@ -1,75 +1,55 @@
 {
-    "name": "hb_grocery",
+    "name": "hb_work_u18",
     "orig": "home",
-    "dest": "wrk_shop",
+    "dest": "work",
     "generation_area": "domestic",
     "attraction_area": "domestic",
     "struct": "mode>dest",
     "gen_model": "rate",
     "generation": {
         "no_car": {
-            "age_18_29": 0.1513,
-            "age_30_49": 0.1335,
-            "age_50_64": 0.1878,
-            "age_65_99": 0.1979
+            "age_7_17": 0.0056
         },
         "has_car": {
-            "age_18_29": 0.1146,
-            "age_30_49": 0.1287,
-            "age_50_64": 0.1356,
-            "age_65_99": 0.2138
+            "age_7_17": 0.0069
         }
     },
     "sec_dest_rate": {
-        "car_drv": 1.0743,
-        "car_pax": 1.0741,
-        "transit": 1.0205
+        "car_drv": 1.0884,
+        "car_pax": 1.1081,
+        "transit": 1.0575
     },
     "impedance_share": {
-        "car_drv": {
-            "aht": [
-                0.0373,
-                0.0131
-            ],
-            "pt": [
-                0.7054,
-                0.7448
-            ],
-            "iht": [
-                0.2573,
-                0.2421
-            ]
-        },
         "car_pax": {
             "aht": [
-                0.0373,
-                0.0131
+                0.7237,
+                0.0213
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.2546,
+                0.3495
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.0217,
+                0.6292
             ]
         },
         "transit": {
             "aht": [
-                0.0373,
-                0.0131
+                0.7237,
+                0.0213
             ],
             "pt": [
-                0.5188,
-                0.4963
+                0.1515,
+                0.1479
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.0217,
+                0.6292
             ],
             "it": [
-                0.1866,
-                0.2485
+                0.1031,
+                0.2016
             ]
         },
         "bike": {
@@ -85,25 +65,21 @@
             ]
         }
     },
-    "activity_time": 0.7,
-    "parking_cost_share": 1.0,
-    "car_cost_sharing": 1.0,
+    "activity_time": 7.2,
+    "parking_cost_share": 0.5,
+    "car_cost_sharing": 0.0,
     "occupancy": {
-        "car_drv": 1.53,
-        "car_pax": 2.395
+        "car_drv": 1.152,
+        "car_pax": 2.055
     },
     "distance_boundaries": {
-        "car_drv": [
-            0,
-            100
-        ],
         "car_pax": [
             0,
-            100
+            300
         ],
         "transit": [
             0,
-            100
+            300
         ],
         "bike": [
             0,
@@ -115,127 +91,101 @@
         ]
     },
     "destination_choice": {
-        "car_drv": {
-            "attraction": {},
-            "impedance": {
-                "time": -0.08229,
-                "cost": -0.2317
-            },
-            "log": {
-                "attraction_size": 1,
-                "cost": -0.3384
-            },
-            "attraction_size": {
-                "wrk_shop": 1
-            }
-        },
         "car_pax": {
             "attraction": { },
             "impedance": {
-                "time": -0.07864,
-                "cost": -0.2317
+                "time": -0.0587,
+                "cost": -0.05483
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3384
+                "cost": -0.183
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "workplaces": 1
             }
         },
         "transit": {
             "attraction": {
-                "within_zone_inf": -1
+                "within_zone_inf": -1,
+                "sh_office": 1.531
             },
             "impedance": {
-                "time": -0.02791
+                "time": -0.01049,
+                "cost": -0.05483
             },
             "log": {
                 "attraction_size": 1,
-                "cost": -0.3384
+                "cost": -0.183
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "workplaces": 1
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000138
+                "density_pop_wrk": -0.000022
             },
             "impedance": {
-                "dist": -0.4097
+                "dist": -0.142
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "workplaces": 1
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.9594
+                "dist": -0.4948
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1
+                "workplaces": 1
             }
         }
     },
     "mode_choice": {
-        "car_drv": {
-            "constant": -6.593,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 0.6443
-            },
-            "individual_dummy": {
-                "sh_cars1_hh1": 6.45,
-                "sh_cars2_hh2": 6.45,
-                "sh_cars1_hh2": 5.473
-            }
-        },
         "car_pax": {
-            "constant": -6.148,
+            "constant": -4.458,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.8643
             },
             "individual_dummy": {
-                "sh_cars1_hh2": 2.937,
-                "sh_cars2_hh2": 2.937
+                "sh_cars1_hh2": 0.9409,
+                "sh_cars2_hh2": 0.9409
             }
         },
         "transit": {
-            "constant": -4.645,
+            "constant": -2.582,
             "generation": {
-                "HSL": 1.186,
-                "Tampere": 1.317,
-                "Turku": 1.36
+                "HSL": 1.298,
+                "Tampere": 0.5799,
+                "Turku": 0.4511
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.8643
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -3.364,
+            "constant": -1.288,
             "generation": {
-                "Oulu": 1.024
+                "Oulu": 0.8642
             },
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.8643
             },
             "individual_dummy": {}
         },
@@ -245,48 +195,37 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.6443
+                "logsum": 0.8643
             },
             "individual_dummy": {}
         },
         "scaling": {
-            "car_drv": {
-                "constant": 0.6443,
-                "individual_dummy": {
-                    "sh_cars1_hh1": 0.6443,
-                    "sh_cars2_hh2": 0.6443,
-                    "sh_cars1_hh2": 0.6443
-                }
-            },
             "car_pax": {
-                "constant": 0.6443,
+                "constant": 0.8643,
                 "individual_dummy": {
-                    "sh_cars1_hh2": 0.6443,
-                    "sh_cars2_hh2": 0.6443
+                    "sh_cars1_hh2": 0.8643,
+                    "sh_cars2_hh2": 0.8643
                 }
             },
             "transit": {
-                "constant": 0.6443,
+                "constant": 0.8643,
                 "generation": {
-                    "HSL": 0.6443,
-                    "Tampere": 0.6443,
-                    "Turku": 0.6443
+                    "HSL": 0.8643,
+                    "Tampere": 0.8643,
+                    "Turku": 0.8643
                 }
             },
             "bike": {
-                "constant": 0.6443,
+                "constant": 0.8643,
                 "generation": {
-                    "Oulu": 0.6443
+                    "Oulu": 0.8643
                 }
             },
             "walk": {
-                "constant": 0.6443
+                "constant": 0.8643
             }
         },
         "calibration": {
-            "car_drv": {
-                "constant": 0.0
-            },
             "car_pax": {
                 "constant": 0.0
             },
@@ -304,30 +243,30 @@
     "demand_share": {
         "bike": {
             "aht": [
-                0.0373,
-                0.0131
+                0.7237,
+                0.0213
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.2546,
+                0.3495
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.0217,
+                0.6292
             ]
         },
         "walk": {
             "aht": [
-                0.0373,
-                0.0131
+                0.7237,
+                0.0213
             ],
             "pt": [
-                0.7054,
-                0.7448
+                0.2546,
+                0.3495
             ],
             "iht": [
-                0.2573,
-                0.2421
+                0.0217,
+                0.6292
             ]
         }
     }

--- a/Scripts/parameters/demand/ob_other.json
+++ b/Scripts/parameters/demand/ob_other.json
@@ -111,29 +111,29 @@
         "car_drv": {
             "attraction": {},
             "impedance": {
-                "time": -0.09033
+                "time": -0.09058
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 1.188153,
-                "wrk_hospitality": 1.239862
+                "wrk_recreation": 1.189461,
+                "wrk_hospitality": 1.241226
             }
         },
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.07398
+                "time": -0.07407
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 1.188153,
-                "wrk_hospitality": 1.239862
+                "wrk_recreation": 1.189461,
+                "wrk_hospitality": 1.241226
             }
         },
         "transit": {
@@ -141,93 +141,94 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.02819
+                "time": -0.02835
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 1.188153,
-                "wrk_hospitality": 1.239862
+                "wrk_recreation": 1.189461,
+                "wrk_hospitality": 1.241226
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000167
+                "density_pop_wrk": -0.000168
             },
             "impedance": {
-                "dist": -0.4033
+                "dist": -0.4014
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 1.188153,
-                "wrk_hospitality": 1.239862
+                "wrk_recreation": 1.189461,
+                "wrk_hospitality": 1.241226
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.6916
+                "dist": -0.6937
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 1.188153,
-                "wrk_hospitality": 1.239862
+                "wrk_recreation": 1.189461,
+                "wrk_hospitality": 1.241226
             }
         }
     },
     "mode_choice": {
         "car_drv": {
-            "constant": -4.868,
+            "constant": -3.908,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5265
+                "logsum": 0.5376
             },
             "individual_dummy": {
-                "ob_other_parent_car_drv_share": 5.683
+                "ob_other_parent_car_drv_share*sh_age_7_17": 4.743,
+                "ob_other_parent_car_drv_share*sh_age_18_99": 4.743
             }
         },
         "car_pax": {
-            "constant": -3.368,
+            "constant": -3.32,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5265
+                "logsum": 0.5376
             },
             "individual_dummy": {
-                "ob_other_parent_car_pax_share": 2.481
+                "ob_other_parent_car_pax_share": 2.339
             }
         },
         "transit": {
-            "constant": -4.495,
+            "constant": -4.399,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5265
+                "logsum": 0.5376
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -5.511,
+            "constant": -5.425,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5265
+                "logsum": 0.5376
             },
             "individual_dummy": {
-                "ob_other_parent_bike_share": 7.618
+                "ob_other_parent_bike_share": 7.532
             }
         },
         "walk": {
@@ -236,34 +237,35 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5265
+                "logsum": 0.5376
             },
             "individual_dummy": {}
         },
         "scaling": {
             "car_drv": {
-                "constant": 0.5265,
+                "constant": 0.5376,
                 "individual_dummy": {
-                    "ob_other_parent_car_drv_share": 0.5265
+                    "ob_other_parent_car_drv_share*sh_age_7_17": 0.5376,
+                    "ob_other_parent_car_drv_share*sh_age_18_99": 0.5376
                 }
             },
             "car_pax": {
-                "constant": 0.5265,
+                "constant": 0.5376,
                 "individual_dummy": {
-                    "ob_other_parent_car_pax_share": 0.5265
+                    "ob_other_parent_car_pax_share": 0.5376
                 }
             },
             "transit": {
-                "constant": 0.5265
+                "constant": 0.5376
             },
             "bike": {
-                "constant": 0.5265,
+                "constant": 0.5376,
                 "individual_dummy": {
-                    "ob_other_parent_bike_share": 0.5265
+                    "ob_other_parent_bike_share": 0.5376
                 }
             },
             "walk": {
-                "constant": 0.5265
+                "constant": 0.5376
             }
         },
         "calibration": {

--- a/Scripts/parameters/demand/ob_other_u18.json
+++ b/Scripts/parameters/demand/ob_other_u18.json
@@ -1,41 +1,25 @@
 {
-    "name": "ob_other",
+    "name": "ob_other_u18",
     "orig": "source",
     "dest": "other",
     "source": [
-        "hb_leisure",
-        "hb_sport",
-        "hb_visit"
+        "hb_leisure_u18",
+        "hb_sport_u18",
+        "hb_visit_u18"
     ],
     "generation_area": "domestic",
     "attraction_area": "domestic",
     "struct": "mode>dest",
     "gen_model": "rate",
     "generation": {
-        "hb_leisure": 0.0262,
-        "hb_sport": 0.0051,
-        "hb_visit": 0.1141
+        "hb_leisure_u18": 0.0262,
+        "hb_sport_u18": 0.0051,
+        "hb_visit_u18": 0.1141
     },
     "sec_dest_rate": {
-        "car_drv": 1.0516,
-        "car_pax": 1.1103,
-        "transit": 1.083
+        "car_drv": 1.0516
     },
     "impedance_share": {
-        "car_drv": {
-            "aht": [
-                0.0171,
-                0.0048
-            ],
-            "pt": [
-                0.6808,
-                0.6455
-            ],
-            "iht": [
-                0.3021,
-                0.3497
-            ]
-        },
         "car_pax": {
             "aht": [
                 0.0171,
@@ -86,10 +70,6 @@
     "car_cost_sharing": 0.0,
     "occupancy": {},
     "distance_boundaries": {
-        "car_drv": [
-            0,
-            100
-        ],
         "car_pax": [
             0,
             100
@@ -108,20 +88,6 @@
         ]
     },
     "destination_choice": {
-        "car_drv": {
-            "attraction": {},
-            "impedance": {
-                "time": -0.09058
-            },
-            "log": {
-                "attraction_size": 1
-            },
-            "attraction_size": {
-                "wrk_shop": 1,
-                "wrk_recreation": 1.189461,
-                "wrk_hospitality": 1.241226
-            }
-        },
         "car_pax": {
             "attraction": {},
             "impedance": {
@@ -184,18 +150,6 @@
         }
     },
     "mode_choice": {
-        "car_drv": {
-            "constant": -3.908,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 0.5376
-            },
-            "individual_dummy": {
-                "ob_other_parent_car_drv_share": 4.743
-            }
-        },
         "car_pax": {
             "constant": -3.32,
             "generation": {},
@@ -241,12 +195,6 @@
             "individual_dummy": {}
         },
         "scaling": {
-            "car_drv": {
-                "constant": 0.5376,
-                "individual_dummy": {
-                    "ob_other_parent_car_drv_share": 0.5376
-                }
-            },
             "car_pax": {
                 "constant": 0.5376,
                 "individual_dummy": {
@@ -267,9 +215,6 @@
             }
         },
         "calibration": {
-            "car_drv": {
-                "constant": 0.0
-            },
             "car_pax": {
                 "constant": 0.0
             },

--- a/Scripts/parameters/demand/wb_business.json
+++ b/Scripts/parameters/demand/wb_business.json
@@ -107,7 +107,7 @@
         "car_drv": {
             "attraction": {},
             "impedance": {
-                "time": -0.05265
+                "time": -0.05263
             },
             "log": {
                 "attraction_size": 1
@@ -119,7 +119,7 @@
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.04474
+                "time": -0.04486
             },
             "log": {
                 "attraction_size": 1
@@ -133,7 +133,7 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.01956
+                "time": -0.01965
             },
             "log": {
                 "attraction_size": 1
@@ -147,7 +147,7 @@
                 "density_pop_wrk": -0.000149
             },
             "impedance": {
-                "dist": -0.4926
+                "dist": -0.4929
             },
             "log": {
                 "attraction_size": 1
@@ -159,7 +159,7 @@
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.9202
+                "dist": -0.9206
             },
             "log": {
                 "attraction_size": 1
@@ -171,7 +171,7 @@
     },
     "mode_choice": {
         "car_drv": {
-            "constant": -2.531,
+            "constant": -2.502,
             "generation": {},
             "attraction": {},
             "impedance": {},
@@ -179,11 +179,12 @@
                 "logsum": 1
             },
             "individual_dummy": {
-                "wb_business_parent_car_drv_share": 2.732
+                "wb_business_parent_car_drv_share*sh_age_7_17": 2.697,
+                "wb_business_parent_car_drv_share*sh_age_18_99": 2.697
             }
         },
         "car_pax": {
-            "constant": -2.671,
+            "constant": -2.672,
             "generation": {},
             "attraction": {},
             "impedance": {},
@@ -193,7 +194,7 @@
             "individual_dummy": {}
         },
         "transit": {
-            "constant": -2.418,
+            "constant": -2.41,
             "generation": {},
             "attraction": {},
             "impedance": {},
@@ -203,7 +204,7 @@
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -2.213,
+            "constant": -2.215,
             "generation": {},
             "attraction": {},
             "impedance": {},
@@ -211,7 +212,7 @@
                 "logsum": 1
             },
             "individual_dummy": {
-                "wb_business_parent_bike_share": 2.717
+                "wb_business_parent_bike_share": 2.725
             }
         },
         "walk": {
@@ -228,7 +229,8 @@
             "car_drv": {
                 "constant": 1,
                 "individual_dummy": {
-                    "wb_business_parent_car_drv_share": 1
+                    "wb_business_parent_car_drv_share*sh_age_7_17": 1,
+                    "wb_business_parent_car_drv_share*sh_age_18_99": 1
                 }
             },
             "car_pax": {

--- a/Scripts/parameters/demand/wb_business_u18.json
+++ b/Scripts/parameters/demand/wb_business_u18.json
@@ -1,71 +1,53 @@
 {
-    "name": "ob_other",
+    "name": "wb_business_u18",
     "orig": "source",
     "dest": "other",
     "source": [
-        "hb_leisure",
-        "hb_sport",
-        "hb_visit"
+        "hb_work_u18"
     ],
     "generation_area": "domestic",
     "attraction_area": "domestic",
     "struct": "mode>dest",
     "gen_model": "rate",
     "generation": {
-        "hb_leisure": 0.0262,
-        "hb_sport": 0.0051,
-        "hb_visit": 0.1141
+        "hb_work_u18": 0.0674
     },
     "sec_dest_rate": {
-        "car_drv": 1.0516,
-        "car_pax": 1.1103,
-        "transit": 1.083
+        "car_drv": 1.1013,
+        "car_pax": 1.0309,
+        "transit": 1.0009
     },
     "impedance_share": {
-        "car_drv": {
-            "aht": [
-                0.0171,
-                0.0048
-            ],
-            "pt": [
-                0.6808,
-                0.6455
-            ],
-            "iht": [
-                0.3021,
-                0.3497
-            ]
-        },
         "car_pax": {
             "aht": [
-                0.0171,
-                0.0048
+                0.2841,
+                0.0415
             ],
             "pt": [
-                0.6808,
-                0.6455
+                0.6965,
+                0.7603
             ],
             "iht": [
-                0.3021,
-                0.3497
+                0.0194,
+                0.1982
             ]
         },
         "transit": {
             "aht": [
-                0.0171,
-                0.0048
+                0.2841,
+                0.0415
             ],
             "pt": [
-                0.422,
-                0.2992
+                0.6843,
+                0.7429
             ],
             "iht": [
-                0.3021,
-                0.3497
+                0.0194,
+                0.1982
             ],
             "it": [
-                0.2588,
-                0.3463
+                0.0122,
+                0.0174
             ]
         },
         "bike": {
@@ -86,17 +68,13 @@
     "car_cost_sharing": 0.0,
     "occupancy": {},
     "distance_boundaries": {
-        "car_drv": [
-            0,
-            100
-        ],
         "car_pax": [
             0,
-            100
+            300
         ],
         "transit": [
             0,
-            100
+            300
         ],
         "bike": [
             0,
@@ -108,32 +86,16 @@
         ]
     },
     "destination_choice": {
-        "car_drv": {
-            "attraction": {},
-            "impedance": {
-                "time": -0.09058
-            },
-            "log": {
-                "attraction_size": 1
-            },
-            "attraction_size": {
-                "wrk_shop": 1,
-                "wrk_recreation": 1.189461,
-                "wrk_hospitality": 1.241226
-            }
-        },
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.07407
+                "time": -0.04486
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1,
-                "wrk_recreation": 1.189461,
-                "wrk_hospitality": 1.241226
+                "workplaces": 1
             }
         },
         "transit": {
@@ -141,93 +103,73 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.02835
+                "time": -0.01965
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1,
-                "wrk_recreation": 1.189461,
-                "wrk_hospitality": 1.241226
+                "workplaces": 1
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000168
+                "density_pop_wrk": -0.000149
             },
             "impedance": {
-                "dist": -0.4014
+                "dist": -0.4929
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1,
-                "wrk_recreation": 1.189461,
-                "wrk_hospitality": 1.241226
+                "workplaces": 1
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.6937
+                "dist": -0.9206
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
-                "wrk_shop": 1,
-                "wrk_recreation": 1.189461,
-                "wrk_hospitality": 1.241226
+                "population": 1
             }
         }
     },
     "mode_choice": {
-        "car_drv": {
-            "constant": -3.908,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 0.5376
-            },
-            "individual_dummy": {
-                "ob_other_parent_car_drv_share": 4.743
-            }
-        },
         "car_pax": {
-            "constant": -3.32,
+            "constant": -2.672,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5376
+                "logsum": 1
             },
-            "individual_dummy": {
-                "ob_other_parent_car_pax_share": 2.339
-            }
+            "individual_dummy": {}
         },
         "transit": {
-            "constant": -4.399,
+            "constant": -2.41,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5376
+                "logsum": 1
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -5.425,
+            "constant": -2.215,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5376
+                "logsum": 1
             },
             "individual_dummy": {
-                "ob_other_parent_bike_share": 7.532
+                "wb_business_parent_bike_share": 2.725
             }
         },
         "walk": {
@@ -236,40 +178,28 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5376
+                "logsum": 1
             },
             "individual_dummy": {}
         },
         "scaling": {
-            "car_drv": {
-                "constant": 0.5376,
-                "individual_dummy": {
-                    "ob_other_parent_car_drv_share": 0.5376
-                }
-            },
             "car_pax": {
-                "constant": 0.5376,
-                "individual_dummy": {
-                    "ob_other_parent_car_pax_share": 0.5376
-                }
+                "constant": 1
             },
             "transit": {
-                "constant": 0.5376
+                "constant": 1
             },
             "bike": {
-                "constant": 0.5376,
+                "constant": 1,
                 "individual_dummy": {
-                    "ob_other_parent_bike_share": 0.5376
+                    "wb_business_parent_bike_share": 1
                 }
             },
             "walk": {
-                "constant": 0.5376
+                "constant": 1
             }
         },
         "calibration": {
-            "car_drv": {
-                "constant": 0.0
-            },
             "car_pax": {
                 "constant": 0.0
             },
@@ -287,30 +217,30 @@
     "demand_share": {
         "bike": {
             "aht": [
-                0.0171,
-                0.0048
+                0.2841,
+                0.0415
             ],
             "pt": [
-                0.6808,
-                0.6455
+                0.6965,
+                0.7603
             ],
             "iht": [
-                0.3021,
-                0.3497
+                0.0194,
+                0.1982
             ]
         },
         "walk": {
             "aht": [
-                0.0171,
-                0.0048
+                0.2841,
+                0.0415
             ],
             "pt": [
-                0.6808,
-                0.6455
+                0.6965,
+                0.7603
             ],
             "iht": [
-                0.3021,
-                0.3497
+                0.0194,
+                0.1982
             ]
         }
     }

--- a/Scripts/parameters/demand/wb_other.json
+++ b/Scripts/parameters/demand/wb_other.json
@@ -111,29 +111,29 @@
         "car_drv": {
             "attraction": {},
             "impedance": {
-                "time": -0.1507
+                "time": -0.1511
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 0.856415,
-                "wrk_hospitality": 1.822848
+                "wrk_recreation": 0.857787,
+                "wrk_hospitality": 1.81957
             }
         },
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.1594
+                "time": -0.1589
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 0.856415,
-                "wrk_hospitality": 1.822848
+                "wrk_recreation": 0.857787,
+                "wrk_hospitality": 1.81957
             }
         },
         "transit": {
@@ -141,91 +141,92 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.02465
+                "time": -0.02483
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 0.856415,
-                "wrk_hospitality": 1.822848
+                "wrk_recreation": 0.857787,
+                "wrk_hospitality": 1.81957
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.00011
+                "density_pop_wrk": -0.000109
             },
             "impedance": {
-                "dist": -0.5305
+                "dist": -0.5311
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 0.856415,
-                "wrk_hospitality": 1.822848
+                "wrk_recreation": 0.857787,
+                "wrk_hospitality": 1.81957
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -1.183
+                "dist": -1.182
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 0.856415,
-                "wrk_hospitality": 1.822848
+                "wrk_recreation": 0.857787,
+                "wrk_hospitality": 1.81957
             }
         }
     },
     "mode_choice": {
         "car_drv": {
-            "constant": -4.989,
+            "constant": -4.252,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.8215
+                "logsum": 0.8367
             },
             "individual_dummy": {
-                "wb_other_parent_car_drv_share": 4.448
+                "wb_other_parent_car_drv_share*sh_age_7_17": 3.716,
+                "wb_other_parent_car_drv_share*sh_age_18_99": 3.716
             }
         },
         "car_pax": {
-            "constant": -2.864,
+            "constant": -2.852,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.8215
+                "logsum": 0.8367
             },
             "individual_dummy": {}
         },
         "transit": {
-            "constant": -6.289,
+            "constant": -6.208,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.8215
+                "logsum": 0.8367
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -5.616,
+            "constant": -5.531,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.8215
+                "logsum": 0.8367
             },
             "individual_dummy": {
-                "wb_other_parent_bike_share": 4.057
+                "wb_other_parent_bike_share": 3.995
             }
         },
         "walk": {
@@ -234,31 +235,32 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.8215
+                "logsum": 0.8367
             },
             "individual_dummy": {}
         },
         "scaling": {
             "car_drv": {
-                "constant": 0.8215,
+                "constant": 0.8367,
                 "individual_dummy": {
-                    "wb_other_parent_car_drv_share": 0.8215
+                    "wb_other_parent_car_drv_share*sh_age_7_17": 0.8367,
+                    "wb_other_parent_car_drv_share*sh_age_18_99": 0.8367
                 }
             },
             "car_pax": {
-                "constant": 0.8215
+                "constant": 0.8367
             },
             "transit": {
-                "constant": 0.8215
+                "constant": 0.8367
             },
             "bike": {
-                "constant": 0.8215,
+                "constant": 0.8367,
                 "individual_dummy": {
-                    "wb_other_parent_bike_share": 0.8215
+                    "wb_other_parent_bike_share": 0.8367
                 }
             },
             "walk": {
-                "constant": 0.8215
+                "constant": 0.8367
             }
         },
         "calibration": {

--- a/Scripts/parameters/demand/wb_other.json
+++ b/Scripts/parameters/demand/wb_other.json
@@ -4,7 +4,6 @@
     "dest": "other",
     "source": [
         "hb_work",
-        "hb_edu_basic",
         "hb_edu_student"
     ],
     "generation_area": "domestic",
@@ -13,7 +12,6 @@
     "gen_model": "rate",
     "generation": {
         "hb_work": 0.1104,
-        "hb_edu_basic": 0.0287,
         "hb_edu_student": 0.0319
     },
     "sec_dest_rate": {
@@ -193,8 +191,7 @@
                 "logsum": 0.8367
             },
             "individual_dummy": {
-                "wb_other_parent_car_drv_share*sh_age_7_17": 3.716,
-                "wb_other_parent_car_drv_share*sh_age_18_99": 3.716
+                "wb_other_parent_car_drv_share": 3.716
             }
         },
         "car_pax": {
@@ -243,8 +240,7 @@
             "car_drv": {
                 "constant": 0.8367,
                 "individual_dummy": {
-                    "wb_other_parent_car_drv_share*sh_age_7_17": 0.8367,
-                    "wb_other_parent_car_drv_share*sh_age_18_99": 0.8367
+                    "wb_other_parent_car_drv_share": 0.8367
                 }
             },
             "car_pax": {

--- a/Scripts/parameters/demand/wb_other_u18.json
+++ b/Scripts/parameters/demand/wb_other_u18.json
@@ -1,71 +1,57 @@
 {
-    "name": "ob_other",
+    "name": "wb_other_u18",
     "orig": "source",
     "dest": "other",
     "source": [
-        "hb_leisure",
-        "hb_sport",
-        "hb_visit"
+        "hb_work_u18",
+        "hb_edu_basic",
+        "hb_edu_student_u18"
     ],
     "generation_area": "domestic",
     "attraction_area": "domestic",
     "struct": "mode>dest",
     "gen_model": "rate",
     "generation": {
-        "hb_leisure": 0.0262,
-        "hb_sport": 0.0051,
-        "hb_visit": 0.1141
+        "hb_work_u18": 0.1104,
+        "hb_edu_basic": 0.0287,
+        "hb_edu_student_u18": 0.0319
     },
     "sec_dest_rate": {
-        "car_drv": 1.0516,
-        "car_pax": 1.1103,
-        "transit": 1.083
+        "car_drv": 1.0264,
+        "car_pax": 1.0503,
+        "transit": 1.0
     },
     "impedance_share": {
-        "car_drv": {
-            "aht": [
-                0.0171,
-                0.0048
-            ],
-            "pt": [
-                0.6808,
-                0.6455
-            ],
-            "iht": [
-                0.3021,
-                0.3497
-            ]
-        },
         "car_pax": {
             "aht": [
-                0.0171,
-                0.0048
+                0.0352,
+                0.0118
             ],
             "pt": [
-                0.6808,
-                0.6455
+                0.9177,
+                0.9186
             ],
             "iht": [
-                0.3021,
-                0.3497
+                0.0471,
+                0.0696
             ]
         },
         "transit": {
             "aht": [
-                0.0171,
-                0.0048
+                0.0352,
+                0.0118
             ],
             "pt": [
-                0.422,
-                0.2992
+                0.9106,
+                0.8963
             ],
             "iht": [
-                0.3021,
-                0.3497
+                0.0471,
+                0.0696
             ],
             "it": [
-                0.2588,
-                0.3463
+                0.0071,
+                0.0223
             ]
         },
         "bike": {
@@ -86,10 +72,6 @@
     "car_cost_sharing": 0.0,
     "occupancy": {},
     "distance_boundaries": {
-        "car_drv": [
-            0,
-            100
-        ],
         "car_pax": [
             0,
             100
@@ -108,32 +90,18 @@
         ]
     },
     "destination_choice": {
-        "car_drv": {
-            "attraction": {},
-            "impedance": {
-                "time": -0.09058
-            },
-            "log": {
-                "attraction_size": 1
-            },
-            "attraction_size": {
-                "wrk_shop": 1,
-                "wrk_recreation": 1.189461,
-                "wrk_hospitality": 1.241226
-            }
-        },
         "car_pax": {
             "attraction": {},
             "impedance": {
-                "time": -0.07407
+                "time": -0.1589
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 1.189461,
-                "wrk_hospitality": 1.241226
+                "wrk_recreation": 0.857787,
+                "wrk_hospitality": 1.81957
             }
         },
         "transit": {
@@ -141,93 +109,79 @@
                 "within_zone_inf": -1
             },
             "impedance": {
-                "time": -0.02835
+                "time": -0.02483
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 1.189461,
-                "wrk_hospitality": 1.241226
+                "wrk_recreation": 0.857787,
+                "wrk_hospitality": 1.81957
             }
         },
         "bike": {
             "attraction": {
-                "density_pop_wrk": -0.000168
+                "density_pop_wrk": -0.000109
             },
             "impedance": {
-                "dist": -0.4014
+                "dist": -0.5311
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 1.189461,
-                "wrk_hospitality": 1.241226
+                "wrk_recreation": 0.857787,
+                "wrk_hospitality": 1.81957
             }
         },
         "walk": {
             "attraction": {},
             "impedance": {
-                "dist": -0.6937
+                "dist": -1.182
             },
             "log": {
                 "attraction_size": 1
             },
             "attraction_size": {
                 "wrk_shop": 1,
-                "wrk_recreation": 1.189461,
-                "wrk_hospitality": 1.241226
+                "wrk_recreation": 0.857787,
+                "wrk_hospitality": 1.81957
             }
         }
     },
     "mode_choice": {
-        "car_drv": {
-            "constant": -3.908,
-            "generation": {},
-            "attraction": {},
-            "impedance": {},
-            "log": {
-                "logsum": 0.5376
-            },
-            "individual_dummy": {
-                "ob_other_parent_car_drv_share": 4.743
-            }
-        },
         "car_pax": {
-            "constant": -3.32,
+            "constant": -2.852,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5376
+                "logsum": 0.8367
             },
-            "individual_dummy": {
-                "ob_other_parent_car_pax_share": 2.339
-            }
+            "individual_dummy": {}
         },
         "transit": {
-            "constant": -4.399,
+            "constant": -6.208,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5376
+                "logsum": 0.8367
             },
             "individual_dummy": {}
         },
         "bike": {
-            "constant": -5.425,
+            "constant": -5.531,
             "generation": {},
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5376
+                "logsum": 0.8367
             },
             "individual_dummy": {
-                "ob_other_parent_bike_share": 7.532
+                "wb_other_parent_bike_share": 3.995
             }
         },
         "walk": {
@@ -236,40 +190,28 @@
             "attraction": {},
             "impedance": {},
             "log": {
-                "logsum": 0.5376
+                "logsum": 0.8367
             },
             "individual_dummy": {}
         },
         "scaling": {
-            "car_drv": {
-                "constant": 0.5376,
-                "individual_dummy": {
-                    "ob_other_parent_car_drv_share": 0.5376
-                }
-            },
             "car_pax": {
-                "constant": 0.5376,
-                "individual_dummy": {
-                    "ob_other_parent_car_pax_share": 0.5376
-                }
+                "constant": 0.8367
             },
             "transit": {
-                "constant": 0.5376
+                "constant": 0.8367
             },
             "bike": {
-                "constant": 0.5376,
+                "constant": 0.8367,
                 "individual_dummy": {
-                    "ob_other_parent_bike_share": 0.5376
+                    "wb_other_parent_bike_share": 0.8367
                 }
             },
             "walk": {
-                "constant": 0.5376
+                "constant": 0.8367
             }
         },
         "calibration": {
-            "car_drv": {
-                "constant": 0.0
-            },
             "car_pax": {
                 "constant": 0.0
             },
@@ -287,30 +229,30 @@
     "demand_share": {
         "bike": {
             "aht": [
-                0.0171,
-                0.0048
+                0.0352,
+                0.0118
             ],
             "pt": [
-                0.6808,
-                0.6455
+                0.9177,
+                0.9186
             ],
             "iht": [
-                0.3021,
-                0.3497
+                0.0471,
+                0.0696
             ]
         },
         "walk": {
             "aht": [
-                0.0171,
-                0.0048
+                0.0352,
+                0.0118
             ],
             "pt": [
-                0.6808,
-                0.6455
+                0.9177,
+                0.9186
             ],
             "iht": [
-                0.3021,
-                0.3497
+                0.0471,
+                0.0696
             ]
         }
     }

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -57,7 +57,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.3643173272062361)
+            0.3771866197159744)
         
         print("Model system test done")
 

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -57,7 +57,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.3771866197159744)
+            0.3703886877960877)
         
         print("Model system test done")
 

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -57,7 +57,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.3578027299876198)
+            0.3643173272062361)
         
         print("Model system test done")
 


### PR DESCRIPTION
Restrict availability of car driver mode in estimation.  This makes estimation results considerably better and can have some impact on underestimating car use in rural areas (cannot be validated though).  However, this model-system solution does not work correctly, as the share should not be share of 7-17 population, but share of purpose tours made by 7-17 year old population.

Not sure if we are able to get working solution without agent based model or adding too much complexity. 