### PR TITLE
Add share of row or detached explanatory variable to car ownership model

### DIFF
--- a/Scripts/parameters/car.py
+++ b/Scripts/parameters/car.py
@@ -24,7 +24,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_1_adult_children": 0,
             },
             "calibration": {
-                "constant": 0.295158762
+                "constant": 0.241671346
             }
         },
         "1": {
@@ -47,7 +47,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_1_adult_children": 0.530891,
             },
             "calibration": {
-                "constant": -0.09826214
+                "constant": -0.08120386
             },
         }
     },
@@ -70,7 +70,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0,
             },
             "calibration": {
-                "constant": 0.432910651
+                "constant": 0.367440245
             }
         },
         "1": {
@@ -93,7 +93,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0.197250,
             },
             "calibration": {
-                "constant": -0.05476665
+                "constant": -0.048012218
             }
         },
     },
@@ -116,53 +116,54 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0,
             },
             "calibration": {
-                "constant": -0.35784365
+                "constant": -0.308020961
             }
         },
         "1": {
-            "constant": 4.015710,
+            "constant": 4.014036,
             "generation": {
-                "sqrt_pop_density": -0.020883,
+                "sqrt_pop_density": -0.020899,
             },
             "individual_dummy": {
-                "sh_income_0_19*sh_hh_2_adults_no_children": -1.663979,
-                "sh_income_20_39*sh_hh_2_adults_no_children": -0.225171,
+                "sh_income_0_19*sh_hh_2_adults_no_children": -1.656960,
+                "sh_income_20_39*sh_hh_2_adults_no_children": -0.221326,
                 "sh_income_40_59*sh_hh_2_adults_no_children": 0,
                 "sh_income_60_79*sh_hh_2_adults_no_children": 0,
                 "sh_income_80_99*sh_hh_2_adults_no_children": 0,
                 "sh_income_100_*sh_hh_2_adults_no_children": 0,
-                "sh_income_0_19*sh_hh_2_adults_children": -1.663979+0.379870,
-                "sh_income_20_39*sh_hh_2_adults_children": -0.225171+0.379870,
-                "sh_income_40_59*sh_hh_2_adults_children": 0.379870,
-                "sh_income_60_79*sh_hh_2_adults_children": 0.379870,
-                "sh_income_80_99*sh_hh_2_adults_children": 0.379870,
-                "sh_income_100_*sh_hh_2_adults_children": 0.379870,
+                "sh_income_0_19*sh_hh_2_adults_children": -1.656960+0.374802,
+                "sh_income_20_39*sh_hh_2_adults_children": -0.221326+0.374802,
+                "sh_income_40_59*sh_hh_2_adults_children": 0.374802,
+                "sh_income_60_79*sh_hh_2_adults_children": 0.374802,
+                "sh_income_80_99*sh_hh_2_adults_children": 0.374802,
+                "sh_income_100_*sh_hh_2_adults_children": 0.374802,
             },
             "calibration": {
-                "constant": -0.01644901
+                "constant": -0.032973231
             }
         },
         "2": {
-            "constant": 5.160160,
+            "constant": 4.339155,
             "generation": {
-                "sqrt_pop_density": -0.055125,
+                "sqrt_pop_density": -0.046784,
+                "sh_row_or_detached": 0.842144
             },
             "individual_dummy": {
-                "sh_income_0_19*sh_hh_2_adults_no_children": -2.635365,
-                "sh_income_20_39*sh_hh_2_adults_no_children": -0.866118,
+                "sh_income_0_19*sh_hh_2_adults_no_children": -2.615898,
+                "sh_income_20_39*sh_hh_2_adults_no_children": -0.829158,
                 "sh_income_40_59*sh_hh_2_adults_no_children": 0,
-                "sh_income_60_79*sh_hh_2_adults_no_children": 0.363252,
-                "sh_income_80_99*sh_hh_2_adults_no_children": 0.590681,
-                "sh_income_100_*sh_hh_2_adults_no_children": 1.133864,
-                "sh_income_0_19*sh_hh_2_adults_children": -2.635365+0.573108,
-                "sh_income_20_39*sh_hh_2_adults_children": -0.866118+0.573108,
-                "sh_income_40_59*sh_hh_2_adults_children": 0.573108,
-                "sh_income_60_79*sh_hh_2_adults_children": 0.363252+0.573108,
-                "sh_income_80_99*sh_hh_2_adults_children": 0.590681+0.573108,
-                "sh_income_100_*sh_hh_2_adults_children": 1.133864+0.573108,
+                "sh_income_60_79*sh_hh_2_adults_no_children": 0.361476,
+                "sh_income_80_99*sh_hh_2_adults_no_children": 0.571395,
+                "sh_income_100_*sh_hh_2_adults_no_children": 1.104780,
+                "sh_income_0_19*sh_hh_2_adults_children": -2.615898+0.542211,
+                "sh_income_20_39*sh_hh_2_adults_children": -0.829158+0.542211,
+                "sh_income_40_59*sh_hh_2_adults_children": 0.542211,
+                "sh_income_60_79*sh_hh_2_adults_children": 0.361476+0.542211,
+                "sh_income_80_99*sh_hh_2_adults_children": 0.571395+0.542211,
+                "sh_income_100_*sh_hh_2_adults_children": 1.104780+0.542211,
             },
             "calibration": {
-                "constant": 0.061056609
+                "constant": 0.065435697
             }
         }
     }

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -57,7 +57,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.3578027299876198)
+            0.3530140743834452)
         
         print("Model system test done")
 
@@ -77,7 +77,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.0669301749314726)
+            0.06676074110701656)
 
     def _validate_impedances(self, impedances):
         self.assertIsNotNone(impedances)


### PR DESCRIPTION
-Add share of row or detached explanatory variable to car ownership model regarding choice of 2 cars
-Calibrate car ownership shares
-Update mode shares for tests