### PR TITLE
Add truck classes to mode_assignment_classes

### DIFF
--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -600,7 +600,7 @@ mode_assignment_classes = {
     "pt_car_egr": ["pt_car_egr", "pt_car_acc"],
     "pt_taxi_egr": ["pt_taxi_egr", "pt_taxi_acc"],
     "airpl_car_egr": ["airpl_car_egr", "airpl_car_acc"],
-    "truck: ["truck"],
+    "truck": ["truck"],
     "semi_trailer": ["semi_trailer"],
     "trailer_truck": ["trailer_truck"],
 }

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -599,5 +599,8 @@ mode_assignment_classes = {
     "airpl_car_acc": ["airpl_car_acc", "airpl_car_egr"],
     "pt_car_egr": ["pt_car_egr", "pt_car_acc"],
     "pt_taxi_egr": ["pt_taxi_egr", "pt_taxi_acc"],
-    "airpl_car_egr": ["airpl_car_egr", "airpl_car_acc"]
+    "airpl_car_egr": ["airpl_car_egr", "airpl_car_acc"],
+    "truck: ["truck"],
+    "semi_trailer": ["semi_trailer"],
+    "trailer_truck": ["trailer_truck"],
 }


### PR DESCRIPTION
This fixes a critical issue when importing freight transport matrices directly from freight model.