### PR TITLE
Refine parking cost logic for park-and-ride

### DIFF
--- a/Scripts/assignment/assignment_period.py
+++ b/Scripts/assignment/assignment_period.py
@@ -353,10 +353,21 @@ class AssignmentPeriod(Period):
             network.mode(param.assignment_modes["car"]),
             network.mode(param.assignment_modes["truck"])
         }
+        long_dist_terminal_modes = {network.mode(mode_id) for mode_id in param.long_dist_terminal_modes}
         park_and_ride_mode = network.mode(param.park_and_ride_mode)
+        long_distance_nodes = {node.id for node in network.nodes()
+                                if any(segment.line.mode in long_dist_terminal_modes
+                                       for link in node.incoming_links()
+                                       for segment in link.segments())}
         car_time_zero = []
         for link in network.links():
             linktype = link.type % 100
+            this_link_modes = {segment.line.mode for segment in link.segments()}
+            is_transit_line_link = this_link_modes & long_dist_terminal_modes
+            connects_long_distance = (
+                link.i_node.id in long_distance_nodes
+                or link.j_node.id in long_distance_nodes)
+            is_park_and_ride_connector = connects_long_distance and not is_transit_line_link
             if link.type > 80 and linktype in param.roadclasses:
                 # Car link with standard attributes
                 roadclass = param.roadclasses[linktype]
@@ -394,6 +405,9 @@ class AssignmentPeriod(Period):
             else:
                 # Link with no car traffic
                 link.volume_delay_func = 0
+            if is_park_and_ride_connector:
+                # Park-and-ride connectors
+                link.volume_delay_func = 97
             if link["#buslane"]:
                 if (link.num_lanes == 3
                         and roadclass.num_lanes == ">=3"):
@@ -412,7 +426,7 @@ class AssignmentPeriod(Period):
                         msg = f"Car travel time on link {link.id} is {car_time}"
                         log.error(msg)
                         raise ValueError(msg)
-            if car_modes & link.modes:
+            if (car_modes & link.modes or connects_long_distance) and not is_transit_line_link:
                 link.modes |= {main_mode, park_and_ride_mode}
             else:
                 link.modes -= {main_mode, park_and_ride_mode}

--- a/Scripts/assignment/datatypes/journey_level.py
+++ b/Scripts/assignment/datatypes/journey_level.py
@@ -83,20 +83,19 @@ class JourneyLevel:
             } for mode in param.long_dist_transit_modes[transit_class]]
         if park_and_ride:
             if transit_class in param.car_access_classes:
-                # Park-and-ride (car) mode allowed only on level 0.
-                car = FORBIDDEN if level >= PARKED else NOT_BOARDED
+                car = FORBIDDEN if level >= PARKED else PARKED
                 # If we want parking to be allowed only on specific links
                 # (i.e., park-and-ride facilities), we should specify an
                 # own mode for these links. For now, parking is allowed
                 # on all links where walking to a stop is possible.
-                walk = PARKED if level == NOT_BOARDED else level
+                walk = FORBIDDEN if level == PARKED else level
             elif transit_class in param.car_egress_classes:
                 # Transfer to park-and-ride (car) mode only allowed after first
                 # boarding. If we want parking to be allowed only on specific
                 # links, we should specify an own mode for these links.
                 # For now, parking is allowed on all links where walking
                 # from a stop is possible.
-                car = LEFT if BOARDED_LOCAL < level < FORBIDDEN else FORBIDDEN
+                car = LEFT if BOARDED_LOCAL <= level < FORBIDDEN else FORBIDDEN # A bug fix to fix assymmetry between access and egress? With this fix both now allow BOARDED_LOCAL where as before only access allowed that.
                 walk = FORBIDDEN if level == LEFT else level
             transitions.append({
                 "mode": param.park_and_ride_mode,

--- a/Scripts/assignment/datatypes/transit.py
+++ b/Scripts/assignment/datatypes/transit.py
@@ -261,8 +261,9 @@ class MixedMode(TransitMode):
         })
         if "taxi" not in self.name:
             for mode_cost in aux_transit_times:
-                mode_cost["cost"] = param.park_cost_attr_l
-                mode_cost["cost_perception_factor"] = self.vot_inv
+                if mode_cost["mode"] == param.park_and_ride_mode:
+                    mode_cost["cost"] = param.park_cost_attr_l
+                    mode_cost["cost_perception_factor"] = self.vot_inv
         self.park_ride_results = f"#park_and_ride_vol_{self.name}"
         self.emme_project.create_network_field(
             "LINK", "REAL", self.park_ride_results, self.name,

--- a/Scripts/parameters/assignment.py
+++ b/Scripts/parameters/assignment.py
@@ -98,6 +98,7 @@ volume_delay_funcs = {
     "fd11": "length*(60/ul2)+el1",
     "fd90": "length*(60/ul2)",
     "fd91": "length*(60/ul2)",
+    "fd97": "length*(60/5)",
     "fd99": "length*(60/ul2)",
     # Bike functions
     "fd70": "length*(60/19)",
@@ -455,6 +456,9 @@ long_dist_transit_modes = {
     "pt_car_egr": ['j'],
     "pt_taxi_egr": ['e', 'j'],
     "airpl_car_egr": ['l'],
+}
+long_dist_terminal_modes = {
+    'l', 'j', 'd'
 }
 aux_modes = [
     'a'


### PR DESCRIPTION
This PR fixes multiple issues with existing park-and-ride parking costs that affect the access mode shares for park-and-ride.

1. Set park-and-ride parking cost (from #park_cost_n) only for park-and-ride transfers. Previously park-and-ride parking costs where applied for transfers between all modes.

2. Set park-and-ride parking cost (from #park_cost_n) only for park-and-ride transfers to ship (mode "d") where the people park their cars at the harbor (that is, change mode from 'u' to 'd' at the harbor). Previously transfer parking costs where applied also for preceding transit mode transfers and for cars boarded to ships