### PR TITLE
Add option of 2 cars to 1 driving licence car ownership models

### DIFF
--- a/Scripts/parameters/car.py
+++ b/Scripts/parameters/car.py
@@ -24,31 +24,55 @@ car_ownership = {
                 "sh_income_100_*sh_hh_1_adult_children": 0,
             },
             "calibration": {
-                "constant": 0.283344173
+                "constant": 0.0
             }
         },
         "1": {
-            "constant": 3.176044,
+            "constant": 3.052168,
             "generation": {
-                "sqrt_pop_density": -0.022892,
+                "sqrt_pop_density": -0.022315,
             },
             "individual_dummy": {
-                "sh_income_0_19*sh_hh_1_adult_no_children": -1.616701,
-                "sh_income_20_39*sh_hh_1_adult_no_children": -0.647555,
+                "sh_income_0_19*sh_hh_1_adult_no_children": -1.551594,
+                "sh_income_20_39*sh_hh_1_adult_no_children": -0.592532,
                 "sh_income_40_59*sh_hh_1_adult_no_children": 0,
                 "sh_income_60_79*sh_hh_1_adult_no_children": 0,
                 "sh_income_80_99*sh_hh_1_adult_no_children": 0,
                 "sh_income_100_*sh_hh_1_adult_no_children": 0,
-                "sh_income_0_19*sh_hh_1_adult_children": -1.616701+0.505770,
-                "sh_income_20_39*sh_hh_1_adult_children": -0.647555+0.505770,
-                "sh_income_40_59*sh_hh_1_adult_children": 0.505770,
-                "sh_income_60_79*sh_hh_1_adult_children": 0.505770,
-                "sh_income_80_99*sh_hh_1_adult_children": 0.505770,
-                "sh_income_100_*sh_hh_1_adult_children": 0.505770,
+                "sh_income_0_19*sh_hh_1_adult_children": -1.551594+0.517062,
+                "sh_income_20_39*sh_hh_1_adult_children": -0.592532+0.517062,
+                "sh_income_40_59*sh_hh_1_adult_children": 0.517062,
+                "sh_income_60_79*sh_hh_1_adult_children": 0.517062,
+                "sh_income_80_99*sh_hh_1_adult_children": 0.517062,
+                "sh_income_100_*sh_hh_1_adult_children": 0.517062,
             },
             "calibration": {
-                "constant": -0.093377328
+                "constant": 0.0
             },
+        },
+        "2": {
+            "constant": 1.052763,
+            "generation": {
+                "sqrt_pop_density": -0.0336664,
+                "sh_row_or_detached": 0.584557
+            },
+            "individual_dummy": {
+                "sh_income_0_19*sh_hh_1_adult_no_children": -2.852715,
+                "sh_income_20_39*sh_hh_1_adult_no_children": -1.645923,
+                "sh_income_40_59*sh_hh_1_adult_no_children": 0,
+                "sh_income_60_79*sh_hh_1_adult_no_children": 0,
+                "sh_income_80_99*sh_hh_1_adult_no_children": 0,
+                "sh_income_100_*sh_hh_1_adult_no_children": 0,
+                "sh_income_0_19*sh_hh_1_adult_children": -2.852715+0.146780,
+                "sh_income_20_39*sh_hh_1_adult_children": -1.645923+0.146780,
+                "sh_income_40_59*sh_hh_1_adult_children": 0.146780,
+                "sh_income_60_79*sh_hh_1_adult_children": 0.146780,
+                "sh_income_80_99*sh_hh_1_adult_children": 0.146780,
+                "sh_income_100_*sh_hh_1_adult_children": 0.146780,
+            },
+            "calibration": {
+                "constant": 0.0
+            }
         }
     },
     "hh2_lic1": {
@@ -70,32 +94,56 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0,
             },
             "calibration": {
-                "constant": 0.537551828
+                "constant": 0.0
             }
         },
         "1": {
-            "constant": 4.559945,
+            "constant": 3.879711,
             "generation": {
-                "sqrt_pop_density": -0.026995,
+                "sqrt_pop_density": -0.022994,
             },
             "individual_dummy": {
-                "sh_income_0_19*sh_hh_2_adults_no_children": -1.997495,
-                "sh_income_20_39*sh_hh_2_adults_no_children": -0.852185,
+                "sh_income_0_19*sh_hh_2_adults_no_children": -1.591287,
+                "sh_income_20_39*sh_hh_2_adults_no_children": -0.539662,
                 "sh_income_40_59*sh_hh_2_adults_no_children": 0,
                 "sh_income_60_79*sh_hh_2_adults_no_children": 0,
                 "sh_income_80_99*sh_hh_2_adults_no_children": 0,
                 "sh_income_100_*sh_hh_2_adults_no_children": 0,
-                "sh_income_0_19*sh_hh_2_adults_children": -1.997495+0.275084,
-                "sh_income_20_39*sh_hh_2_adults_children": -0.852185+0.275084,
-                "sh_income_40_59*sh_hh_2_adults_children": 0.275084,
-                "sh_income_60_79*sh_hh_2_adults_children": 0.275084,
-                "sh_income_80_99*sh_hh_2_adults_children": 0.275084,
-                "sh_income_100_*sh_hh_2_adults_children": 0.275084,
+                "sh_income_0_19*sh_hh_2_adults_children": -1.591287+0.144313,
+                "sh_income_20_39*sh_hh_2_adults_children": -0.539662+0.144313,
+                "sh_income_40_59*sh_hh_2_adults_children": 0.144313,
+                "sh_income_60_79*sh_hh_2_adults_children": 0.144313,
+                "sh_income_80_99*sh_hh_2_adults_children": 0.144313,
+                "sh_income_100_*sh_hh_2_adults_children": 0.144313,
             },
             "calibration": {
-                "constant": -0.065788965
+                "constant": 0.0
             }
         },
+        "2": {
+            "constant": 3.105027,
+            "generation": {
+                "sqrt_pop_density": -0.041752,
+                "sh_row_or_detached": 0.974567
+            },
+            "individual_dummy": {
+                "sh_income_0_19*sh_hh_2_adults_no_children": -3.424101,
+                "sh_income_20_39*sh_hh_2_adults_no_children": -1.396488,
+                "sh_income_40_59*sh_hh_2_adults_no_children": 0,
+                "sh_income_60_79*sh_hh_2_adults_no_children": 0.569071,
+                "sh_income_80_99*sh_hh_2_adults_no_children": 1.196244,
+                "sh_income_100_*sh_hh_2_adults_no_children": 1.423148,
+                "sh_income_0_19*sh_hh_2_adults_children": -3.424101+0.587908,
+                "sh_income_20_39*sh_hh_2_adults_children": -1.396488+0.587908,
+                "sh_income_40_59*sh_hh_2_adults_children": 0.587908,
+                "sh_income_60_79*sh_hh_2_adults_children": 0.569071+0.587908,
+                "sh_income_80_99*sh_hh_2_adults_children": 1.196244+0.587908,
+                "sh_income_100_*sh_hh_2_adults_children": 1.423148+0.587908,
+            },
+            "calibration": {
+                "constant": 0.0
+            }
+        }
     },
     "hh2_lic2": {
         "0": {
@@ -116,7 +164,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0,
             },
             "calibration": {
-                "constant": -0.308020961
+                "constant": 0.0
             }
         },
         "1": {
@@ -139,7 +187,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0.374802,
             },
             "calibration": {
-                "constant": -0.032973231
+                "constant": 0.0
             }
         },
         "2": {
@@ -163,7 +211,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 1.104780+0.542211,
             },
             "calibration": {
-                "constant": 0.065435697
+                "constant": 0.0
             }
         }
     }

--- a/Scripts/parameters/car.py
+++ b/Scripts/parameters/car.py
@@ -24,7 +24,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_1_adult_children": 0,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": 0.349753
             }
         },
         "1": {
@@ -47,7 +47,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_1_adult_children": 0.517062,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": -0.09151
             },
         },
         "2": {
@@ -71,7 +71,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_1_adult_children": 0.146780,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": -0.48209
             }
         }
     },
@@ -94,7 +94,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": 0.781539
             }
         },
         "1": {
@@ -117,7 +117,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0.144313,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": 0.34848
             }
         },
         "2": {
@@ -141,7 +141,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 1.423148+0.587908,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": -2.49148
             }
         }
     },
@@ -164,7 +164,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": -0.37957
             }
         },
         "1": {
@@ -187,7 +187,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 0.374802,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": -0.04573
             }
         },
         "2": {
@@ -211,7 +211,7 @@ car_ownership = {
                 "sh_income_100_*sh_hh_2_adults_children": 1.104780+0.542211,
             },
             "calibration": {
-                "constant": 0.0
+                "constant": 0.090096
             }
         }
     }

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -57,7 +57,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.3358288722413431)
+            0.3460777483779709)
         
         print("Model system test done")
 
@@ -77,7 +77,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.06377175686336098)
+            0.0653610422669455)
 
     def _validate_impedances(self, impedances):
         self.assertIsNotNone(impedances)

--- a/Scripts/tests/integration/test_models.py
+++ b/Scripts/tests/integration/test_models.py
@@ -57,7 +57,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.3533924834490201)
+            0.3358288722413431)
         
         print("Model system test done")
 
@@ -77,7 +77,7 @@ class ModelTest(unittest.TestCase):
         # Check that model result does not change
         self.assertAlmostEquals(
             model.mode_share[0]["car_drv"],
-            0.06683445720170633)
+            0.06377175686336098)
 
     def _validate_impedances(self, impedances):
         self.assertIsNotNone(impedances)


### PR DESCRIPTION
-Implement option of 2 cars to 1 driving licence car ownership models
-Update parameters for models accordingly
-Calibrate models by 2 calibration rounds
-Update mode shares